### PR TITLE
Remove stamp files

### DIFF
--- a/bin/bin/gen_jbuild.ml
+++ b/bin/bin/gen_jbuild.ml
@@ -128,22 +128,20 @@ let process_chapters book_dir output_dir =
 
 let topscript_rule ~dep f =
   sprintf {|
-(alias ((name code) (deps (%s.stamp))))
 (alias ((name sexp) (deps (%s.sexp))))
 (rule
  ((targets (%s.sexp))
   (deps    (%s))
   (action  (with-stdout-to ${@}
     (run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
-(rule
- ((targets (%s.stamp))
+
+(alias
+ ((name    code)
   (deps    (%s %s))
   (action  (progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? %s %s.corrected)
-    ))
-  )) |} f f f f f f dep f f
+    (diff? ${<} ${<}.corrected)))))|}
+    f f f f dep
 
 let sh_rule ~dep f =
   (* see https://github.com/ocaml/dune/issues/431 is answered *)

--- a/examples/code/async/jbuild.inc
+++ b/examples/code/async/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (main.topscript.stamp))))
-
 (alias ((name sexp) (deps (main.topscript.sexp))))
 
 (rule (
@@ -11,12 +9,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main.topscript.stamp))
-  (deps    (main.topscript))
+(alias (
+  (name code)
+  (deps (main.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      main.topscript main.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/classes/jbuild.inc
+++ b/examples/code/classes/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (iter.topscript.stamp))))
-
 (alias ((name sexp) (deps (iter.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (iter.topscript.stamp))
-  (deps    (iter.topscript))
+(alias (
+  (name code)
+  (deps (iter.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      iter.topscript iter.topscript.corrected)))))
-
-(alias ((name code) (deps (binary.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (binary.topscript.sexp))))
 
@@ -31,16 +26,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (binary.topscript.stamp))
-  (deps    (binary.topscript))
+(alias (
+  (name code)
+  (deps (binary.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? binary.topscript binary.topscript.corrected)))))
-
-(alias ((name code) (deps (istack.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (istack.topscript.sexp))))
 
@@ -51,16 +43,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (istack.topscript.stamp))
-  (deps    (istack.topscript))
+(alias (
+  (name code)
+  (deps (istack.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? istack.topscript istack.topscript.corrected)))))
-
-(alias ((name code) (deps (initializer.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (initializer.topscript.sexp))))
 
@@ -71,16 +60,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (initializer.topscript.stamp))
-  (deps    (initializer.topscript))
+(alias (
+  (name code)
+  (deps (initializer.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? initializer.topscript initializer.topscript.corrected)))))
-
-(alias ((name code) (deps (stack.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (stack.topscript.sexp))))
 
@@ -91,12 +77,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (stack.topscript.stamp))
-  (deps    (stack.topscript))
+(alias (
+  (name code)
+  (deps (stack.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}            "")
-    (diff?      stack.topscript stack.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/command-line-parsing/jbuild.inc
+++ b/examples/code/command-line-parsing/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (basic.topscript.stamp))))
-
 (alias ((name sexp) (deps (basic.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (basic.topscript.stamp))
-  (deps    (basic.topscript))
+(alias (
+  (name code)
+  (deps (basic.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}            "")
-    (diff?      basic.topscript basic.topscript.corrected)))))
-
-(alias ((name code) (deps (step.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (step.topscript.sexp))))
 
@@ -31,16 +26,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (step.topscript.stamp))
-  (deps    (step.topscript))
+(alias (
+  (name code)
+  (deps (step.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      step.topscript step.topscript.corrected)))))
-
-(alias ((name code) (deps (command_types.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (command_types.topscript.sexp))))
 
@@ -51,16 +43,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (command_types.topscript.stamp))
-  (deps    (command_types.topscript))
+(alias (
+  (name code)
+  (deps (command_types.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? command_types.topscript command_types.topscript.corrected)))))
-
-(alias ((name code) (deps (group.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (group.topscript.sexp))))
 
@@ -71,12 +60,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (group.topscript.stamp))
-  (deps    (group.topscript))
+(alias (
+  (name code)
+  (deps (group.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}            "")
-    (diff?      group.topscript group.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/error-handling/jbuild.inc
+++ b/examples/code/error-handling/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (main.topscript.stamp))))
-
 (alias ((name sexp) (deps (main.topscript.sexp))))
 
 (rule (
@@ -11,12 +9,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main.topscript.stamp))
-  (deps    (main.topscript))
+(alias (
+  (name code)
+  (deps (main.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      main.topscript main.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/fcm/jbuild.inc
+++ b/examples/code/fcm/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (query_handler.topscript.stamp))))
-
 (alias ((name sexp) (deps (query_handler.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (query_handler.topscript.stamp))
-  (deps    (query_handler.topscript))
+(alias (
+  (name code)
+  (deps (query_handler.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? query_handler.topscript query_handler.topscript.corrected)))))
-
-(alias ((name code) (deps (main.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (main.topscript.sexp))))
 
@@ -31,12 +26,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main.topscript.stamp))
-  (deps    (main.topscript))
+(alias (
+  (name code)
+  (deps (main.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      main.topscript main.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/ffi/jbuild.inc
+++ b/examples/code/ffi/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (qsort.topscript.stamp))))
-
 (alias ((name sexp) (deps (qsort.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (qsort.topscript.stamp))
-  (deps    (qsort.topscript))
+(alias (
+  (name code)
+  (deps (qsort.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}            "")
-    (diff?      qsort.topscript qsort.topscript.corrected)))))
-
-(alias ((name code) (deps (posix.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (posix.topscript.sexp))))
 
@@ -31,12 +26,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (posix.topscript.stamp))
-  (deps    (posix.topscript))
+(alias (
+  (name code)
+  (deps (posix.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}            "")
-    (diff?      posix.topscript posix.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/jbuild.inc
+++ b/examples/code/files-modules-and-programs/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (main.topscript.stamp))))
-
 (alias ((name sexp) (deps (main.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main.topscript.stamp))
-  (deps    (main.topscript))
+(alias (
+  (name code)
+  (deps (main.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      main.topscript main.topscript.corrected)))))
-
-(alias ((name code) (deps (intro.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (intro.topscript.sexp))))
 
@@ -31,12 +26,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (intro.topscript.stamp))
-  (deps    (intro.topscript))
+(alias (
+  (name code)
+  (deps (intro.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}            "")
-    (diff?      intro.topscript intro.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/front-end/jbuild.inc
+++ b/examples/code/front-end/jbuild.inc
@@ -112,8 +112,6 @@
   (fallback)
   (action (setenv TERM dumb (with-stdout-to ${@} (run rwo-build eval ${<}))))))
 
-(alias ((name code) (deps (camlp4_toplevel.topscript.stamp))))
-
 (alias ((name sexp) (deps (camlp4_toplevel.topscript.sexp))))
 
 (rule (
@@ -123,14 +121,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (camlp4_toplevel.topscript.stamp))
-  (deps    (camlp4_toplevel.topscript))
+(alias (
+  (name code)
+  (deps (camlp4_toplevel.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? camlp4_toplevel.topscript camlp4_toplevel.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (build_follow_on_function.errsh.sexp))))
 

--- a/examples/code/functors/jbuild.inc
+++ b/examples/code/functors/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (main.topscript.stamp))))
-
 (alias ((name sexp) (deps (main.topscript.sexp))))
 
 (rule (
@@ -11,12 +9,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main.topscript.stamp))
-  (deps    (main.topscript))
+(alias (
+  (name code)
+  (deps (main.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      main.topscript main.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/gadts/jbuild.inc
+++ b/examples/code/gadts/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (main.topscript.stamp))))
-
 (alias ((name sexp) (deps (main.topscript.sexp))))
 
 (rule (
@@ -11,12 +9,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main.topscript.stamp))
-  (deps    (main.topscript))
+(alias (
+  (name code)
+  (deps (main.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      main.topscript main.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/gc/jbuild.inc
+++ b/examples/code/gc/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (tune.topscript.stamp))))
-
 (alias ((name sexp) (deps (tune.topscript.sexp))))
 
 (rule (
@@ -11,12 +9,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (tune.topscript.stamp))
-  (deps    (tune.topscript))
+(alias (
+  (name code)
+  (deps (tune.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      tune.topscript tune.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/guided-tour/jbuild.inc
+++ b/examples/code/guided-tour/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (main.topscript.stamp))))
-
 (alias ((name sexp) (deps (main.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main.topscript.stamp))
-  (deps    (main.topscript))
+(alias (
+  (name code)
+  (deps (main.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      main.topscript main.topscript.corrected)))))
-
-(alias ((name code) (deps (local_let.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (local_let.topscript.sexp))))
 
@@ -31,12 +26,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (local_let.topscript.stamp))
-  (deps    (local_let.topscript))
+(alias (
+  (name code)
+  (deps (local_let.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? local_let.topscript local_let.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/imperative-programming/jbuild.inc
+++ b/examples/code/imperative-programming/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (examples.topscript.stamp))))
-
 (alias ((name sexp) (deps (examples.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (examples.topscript.stamp))
-  (deps    (examples.topscript))
+(alias (
+  (name code)
+  (deps (examples.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? examples.topscript examples.topscript.corrected)))))
-
-(alias ((name code) (deps (value_restriction.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (value_restriction.topscript.sexp))))
 
@@ -31,16 +26,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (value_restriction.topscript.stamp))
-  (deps    (value_restriction.topscript))
+(alias (
+  (name code)
+  (deps (value_restriction.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? value_restriction.topscript value_restriction.topscript.corrected)))))
-
-(alias ((name code) (deps (weak.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (weak.topscript.sexp))))
 
@@ -51,16 +43,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (weak.topscript.stamp))
-  (deps    (weak.topscript))
+(alias (
+  (name code)
+  (deps (weak.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      weak.topscript weak.topscript.corrected)))))
-
-(alias ((name code) (deps (file2.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (file2.topscript.sexp))))
 
@@ -71,16 +60,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (file2.topscript.stamp))
-  (deps    (file2.topscript))
+(alias (
+  (name code)
+  (deps (file2.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}            "")
-    (diff?      file2.topscript file2.topscript.corrected)))))
-
-(alias ((name code) (deps (lazy.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (lazy.topscript.sexp))))
 
@@ -91,16 +77,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (lazy.topscript.stamp))
-  (deps    (lazy.topscript))
+(alias (
+  (name code)
+  (deps (lazy.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      lazy.topscript lazy.topscript.corrected)))))
-
-(alias ((name code) (deps (file.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (file.topscript.sexp))))
 
@@ -111,16 +94,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (file.topscript.stamp))
-  (deps    (file.topscript))
+(alias (
+  (name code)
+  (deps (file.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      file.topscript file.topscript.corrected)))))
-
-(alias ((name code) (deps (ref.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (ref.topscript.sexp))))
 
@@ -131,16 +111,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (ref.topscript.stamp))
-  (deps    (ref.topscript))
+(alias (
+  (name code)
+  (deps (ref.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}          "")
-    (diff?      ref.topscript ref.topscript.corrected)))))
-
-(alias ((name code) (deps (printf.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (printf.topscript.sexp))))
 
@@ -151,16 +128,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (printf.topscript.stamp))
-  (deps    (printf.topscript))
+(alias (
+  (name code)
+  (deps (printf.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? printf.topscript printf.topscript.corrected)))))
-
-(alias ((name code) (deps (letrec.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (letrec.topscript.sexp))))
 
@@ -171,16 +145,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (letrec.topscript.stamp))
-  (deps    (letrec.topscript))
+(alias (
+  (name code)
+  (deps (letrec.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? letrec.topscript letrec.topscript.corrected)))))
-
-(alias ((name code) (deps (order.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (order.topscript.sexp))))
 
@@ -191,16 +162,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (order.topscript.stamp))
-  (deps    (order.topscript))
+(alias (
+  (name code)
+  (deps (order.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}            "")
-    (diff?      order.topscript order.topscript.corrected)))))
-
-(alias ((name code) (deps (for.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (for.topscript.sexp))))
 
@@ -211,16 +179,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (for.topscript.stamp))
-  (deps    (for.topscript))
+(alias (
+  (name code)
+  (deps (for.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}          "")
-    (diff?      for.topscript for.topscript.corrected)))))
-
-(alias ((name code) (deps (fib.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (fib.topscript.sexp))))
 
@@ -231,16 +196,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (fib.topscript.stamp))
-  (deps    (fib.topscript))
+(alias (
+  (name code)
+  (deps (fib.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}          "")
-    (diff?      fib.topscript fib.topscript.corrected)))))
-
-(alias ((name code) (deps (memo.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (memo.topscript.sexp))))
 
@@ -251,12 +213,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (memo.topscript.stamp))
-  (deps    (memo.topscript))
+(alias (
+  (name code)
+  (deps (memo.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      memo.topscript memo.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/json/jbuild.inc
+++ b/examples/code/json/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (install.topscript.stamp))))
-
 (alias ((name sexp) (deps (install.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (install.topscript.stamp))
-  (deps    (install.topscript))
+(alias (
+  (name code)
+  (deps (install.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? install.topscript install.topscript.corrected)))))
-
-(alias ((name code) (deps (parse_book.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (parse_book.topscript.sexp))))
 
@@ -31,16 +26,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (parse_book.topscript.stamp))
+(alias (
+  (name code)
   (deps (parse_book.topscript book.json))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? parse_book.topscript parse_book.topscript.corrected)))))
-
-(alias ((name code) (deps (build_json.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (build_json.topscript.sexp))))
 
@@ -51,14 +43,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (build_json.topscript.stamp))
-  (deps    (build_json.topscript))
+(alias (
+  (name code)
+  (deps (build_json.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? build_json.topscript build_json.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (build_github_atd.sh.sexp))))
 

--- a/examples/code/lists-and-patterns/jbuild.inc
+++ b/examples/code/lists-and-patterns/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (poly.topscript.stamp))))
-
 (alias ((name sexp) (deps (poly.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (poly.topscript.stamp))
-  (deps    (poly.topscript))
+(alias (
+  (name code)
+  (deps (poly.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      poly.topscript poly.topscript.corrected)))))
-
-(alias ((name code) (deps (main.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (main.topscript.sexp))))
 
@@ -31,12 +26,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main.topscript.stamp))
-  (deps    (main.topscript))
+(alias (
+  (name code)
+  (deps (main.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      main.topscript main.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/maps-and-hash-tables/jbuild.inc
+++ b/examples/code/maps-and-hash-tables/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (core_phys_equal.topscript.stamp))))
-
 (alias ((name sexp) (deps (core_phys_equal.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (core_phys_equal.topscript.stamp))
-  (deps    (core_phys_equal.topscript))
+(alias (
+  (name code)
+  (deps (core_phys_equal.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? core_phys_equal.topscript core_phys_equal.topscript.corrected)))))
-
-(alias ((name code) (deps (main.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (main.topscript.sexp))))
 
@@ -31,12 +26,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main.topscript.stamp))
-  (deps    (main.topscript))
+(alias (
+  (name code)
+  (deps (main.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      main.topscript main.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/memory-repr/jbuild.inc
+++ b/examples/code/memory-repr/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (simple_record.topscript.stamp))))
-
 (alias ((name sexp) (deps (simple_record.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (simple_record.topscript.stamp))
-  (deps    (simple_record.topscript))
+(alias (
+  (name code)
+  (deps (simple_record.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? simple_record.topscript simple_record.topscript.corrected)))))
-
-(alias ((name code) (deps (reprs.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (reprs.topscript.sexp))))
 
@@ -31,12 +26,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (reprs.topscript.stamp))
-  (deps    (reprs.topscript))
+(alias (
+  (name code)
+  (deps (reprs.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}            "")
-    (diff?      reprs.topscript reprs.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/objects/jbuild.inc
+++ b/examples/code/objects/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (polymorphism.topscript.stamp))))
-
 (alias ((name sexp) (deps (polymorphism.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (polymorphism.topscript.stamp))
-  (deps    (polymorphism.topscript))
+(alias (
+  (name code)
+  (deps (polymorphism.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? polymorphism.topscript polymorphism.topscript.corrected)))))
-
-(alias ((name code) (deps (stack.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (stack.topscript.sexp))))
 
@@ -31,16 +26,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (stack.topscript.stamp))
-  (deps    (stack.topscript))
+(alias (
+  (name code)
+  (deps (stack.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}            "")
-    (diff?      stack.topscript stack.topscript.corrected)))))
-
-(alias ((name code) (deps (subtyping.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (subtyping.topscript.sexp))))
 
@@ -51,16 +43,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (subtyping.topscript.stamp))
-  (deps    (subtyping.topscript))
+(alias (
+  (name code)
+  (deps (subtyping.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? subtyping.topscript subtyping.topscript.corrected)))))
-
-(alias ((name code) (deps (immutable.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (immutable.topscript.sexp))))
 
@@ -71,16 +60,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (immutable.topscript.stamp))
-  (deps    (immutable.topscript))
+(alias (
+  (name code)
+  (deps (immutable.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? immutable.topscript immutable.topscript.corrected)))))
-
-(alias ((name code) (deps (row_polymorphism.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (row_polymorphism.topscript.sexp))))
 
@@ -91,12 +77,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (row_polymorphism.topscript.stamp))
-  (deps    (row_polymorphism.topscript))
+(alias (
+  (name code)
+  (deps (row_polymorphism.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? row_polymorphism.topscript row_polymorphism.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/records/jbuild.inc
+++ b/examples/code/records/jbuild.inc
@@ -8,8 +8,6 @@
   (fallback)
   (action (setenv TERM dumb (with-stdout-to ${@} (run rwo-build eval ${<}))))))
 
-(alias ((name code) (deps (main.topscript.stamp))))
-
 (alias ((name sexp) (deps (main.topscript.sexp))))
 
 (rule (
@@ -19,16 +17,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main.topscript.stamp))
-  (deps    (main.topscript))
+(alias (
+  (name code)
+  (deps (main.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      main.topscript main.topscript.corrected)))))
-
-(alias ((name code) (deps (main2.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (main2.topscript.sexp))))
 
@@ -39,12 +34,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main2.topscript.stamp))
-  (deps    (main2.topscript))
+(alias (
+  (name code)
+  (deps (main2.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}            "")
-    (diff?      main2.topscript main2.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/sexpr/jbuild.inc
+++ b/examples/code/sexpr/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (inline_sexp.topscript.stamp))))
-
 (alias ((name sexp) (deps (inline_sexp.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (inline_sexp.topscript.stamp))
-  (deps    (inline_sexp.topscript))
+(alias (
+  (name code)
+  (deps (inline_sexp.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? inline_sexp.topscript inline_sexp.topscript.corrected)))))
-
-(alias ((name code) (deps (sexp_default.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (sexp_default.topscript.sexp))))
 
@@ -31,16 +26,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (sexp_default.topscript.stamp))
-  (deps    (sexp_default.topscript))
+(alias (
+  (name code)
+  (deps (sexp_default.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? sexp_default.topscript sexp_default.topscript.corrected)))))
-
-(alias ((name code) (deps (to_from_sexp.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (to_from_sexp.topscript.sexp))))
 
@@ -51,16 +43,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (to_from_sexp.topscript.stamp))
-  (deps    (to_from_sexp.topscript))
+(alias (
+  (name code)
+  (deps (to_from_sexp.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? to_from_sexp.topscript to_from_sexp.topscript.corrected)))))
-
-(alias ((name code) (deps (sexp_option.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (sexp_option.topscript.sexp))))
 
@@ -71,16 +60,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (sexp_option.topscript.stamp))
-  (deps    (sexp_option.topscript))
+(alias (
+  (name code)
+  (deps (sexp_option.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? sexp_option.topscript sexp_option.topscript.corrected)))))
-
-(alias ((name code) (deps (sexp_opaque.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (sexp_opaque.topscript.sexp))))
 
@@ -91,16 +77,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (sexp_opaque.topscript.stamp))
-  (deps    (sexp_opaque.topscript))
+(alias (
+  (name code)
+  (deps (sexp_opaque.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? sexp_opaque.topscript sexp_opaque.topscript.corrected)))))
-
-(alias ((name code) (deps (print_sexp.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (print_sexp.topscript.sexp))))
 
@@ -111,16 +94,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (print_sexp.topscript.stamp))
-  (deps    (print_sexp.topscript))
+(alias (
+  (name code)
+  (deps (print_sexp.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? print_sexp.topscript print_sexp.topscript.corrected)))))
-
-(alias ((name code) (deps (manually_making_sexp.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (manually_making_sexp.topscript.sexp))))
 
@@ -131,16 +111,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (manually_making_sexp.topscript.stamp))
-  (deps    (manually_making_sexp.topscript))
+(alias (
+  (name code)
+  (deps (manually_making_sexp.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff?
-     manually_making_sexp.topscript
-     manually_making_sexp.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (list_top_packages.sh.sexp))))
 
@@ -149,8 +126,6 @@
   (deps    (list_top_packages.sh))
   (fallback)
   (action (setenv TERM dumb (with-stdout-to ${@} (run rwo-build eval ${<}))))))
-
-(alias ((name code) (deps (example_load.topscript.stamp))))
 
 (alias ((name sexp) (deps (example_load.topscript.sexp))))
 
@@ -161,17 +136,14 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (example_load.topscript.stamp))
+(alias (
+  (name code)
   (deps (
     example_load.topscript example.scm example_broken.scm comment_heavy.scm))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? example_load.topscript example_load.topscript.corrected)))))
-
-(alias ((name code) (deps (auto_making_sexp.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (auto_making_sexp.topscript.sexp))))
 
@@ -182,16 +154,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (auto_making_sexp.topscript.stamp))
-  (deps    (auto_making_sexp.topscript))
+(alias (
+  (name code)
+  (deps (auto_making_sexp.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? auto_making_sexp.topscript auto_making_sexp.topscript.corrected)))))
-
-(alias ((name code) (deps (sexp_list.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (sexp_list.topscript.sexp))))
 
@@ -202,16 +171,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (sexp_list.topscript.stamp))
-  (deps    (sexp_list.topscript))
+(alias (
+  (name code)
+  (deps (sexp_list.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? sexp_list.topscript sexp_list.topscript.corrected)))))
-
-(alias ((name code) (deps (sexp_printer.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (sexp_printer.topscript.sexp))))
 
@@ -222,12 +188,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (sexp_printer.topscript.stamp))
-  (deps    (sexp_printer.topscript))
+(alias (
+  (name code)
+  (deps (sexp_printer.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? sexp_printer.topscript sexp_printer.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/variables-and-functions/jbuild.inc
+++ b/examples/code/variables-and-functions/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (main.topscript.stamp))))
-
 (alias ((name sexp) (deps (main.topscript.sexp))))
 
 (rule (
@@ -11,12 +9,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main.topscript.stamp))
-  (deps    (main.topscript))
+(alias (
+  (name code)
+  (deps (main.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      main.topscript main.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/variants/jbuild.inc
+++ b/examples/code/variants/jbuild.inc
@@ -1,7 +1,5 @@
 (jbuild_version 1)
 
-(alias ((name code) (deps (blang.topscript.stamp))))
-
 (alias ((name sexp) (deps (blang.topscript.sexp))))
 
 (rule (
@@ -11,16 +9,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (blang.topscript.stamp))
-  (deps    (blang.topscript))
+(alias (
+  (name code)
+  (deps (blang.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}            "")
-    (diff?      blang.topscript blang.topscript.corrected)))))
-
-(alias ((name code) (deps (logger.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (logger.topscript.sexp))))
 
@@ -31,16 +26,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (logger.topscript.stamp))
-  (deps    (logger.topscript))
+(alias (
+  (name code)
+  (deps (logger.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? logger.topscript logger.topscript.corrected)))))
-
-(alias ((name code) (deps (main.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (main.topscript.sexp))))
 
@@ -51,16 +43,13 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (main.topscript.stamp))
-  (deps    (main.topscript))
+(alias (
+  (name code)
+  (deps (main.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@}           "")
-    (diff?      main.topscript main.topscript.corrected)))))
-
-(alias ((name code) (deps (catch_all.topscript.stamp))))
+    (diff? ${<} ${<}.corrected)))))
 
 (alias ((name sexp) (deps (catch_all.topscript.sexp))))
 
@@ -71,12 +60,11 @@
     with-stdout-to ${@} (
       run ocaml-topexpect -dry-run -sexp -short-paths -verbose ${<})))))
 
-(rule (
-  (targets (catch_all.topscript.stamp))
-  (deps    (catch_all.topscript))
+(alias (
+  (name code)
+  (deps (catch_all.topscript))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
-    (write-file ${@} "")
-    (diff? catch_all.topscript catch_all.topscript.corrected)))))
+    (diff? ${<} ${<}.corrected)))))
 


### PR DESCRIPTION
(This is based on top of #2855, #2856 and #2857).

The interesting commit here is fccb947 which replaces stamp files with a `code` alias.  9ff150d shows the difference in the auto-generated files, after running `make dep`.