### PR TITLE
Re-enable freq-obuild example

### DIFF
--- a/examples/code/files-modules-and-programs/freq-obuild/freq.sh
+++ b/examples/code/files-modules-and-programs/freq-obuild/freq.sh
@@ -1,5 +1,14 @@
 ### build
   $ jbuilder build freq.bc
 ### test
-  $ # NOTE(samoht): temporary disable this test as it blocks the CI
-  $ # strings `which ocamlopt` | ./_build/default/freq.bc
+  $ strings `which ocamlopt` | ./_build/default/freq.bc
+   92: <hov2>
+   76: list.ml
+   54: bytecomp/matching.ml
+   53: p` <
+   47: typing/env.ml
+   46: <hov>
+   43: string.ml
+   42: typing/parmatch.ml
+   41: typing/ctype.ml
+   40: utils/misc.ml


### PR DESCRIPTION
Now that the shell script is not run by the CI, it should not be
a problem anymore.