### PR TITLE
Base in maps v2

### DIFF
--- a/book/13-maps-and-hashtables.html
+++ b/book/13-maps-and-hashtables.html
@@ -67,7 +67,7 @@
 	  count of the specified string by 1; and <code>to_list</code>
 	  returns the list of nonzero frequencies.</p>
 
-	<p>Here's the implementation:</p>
+	<p>Here's the implementation.</p>
 
 	<link rel="import" href="code/files-modules-and-programs/freq-fast/counter.ml"/>
 
@@ -88,22 +88,26 @@
 	  comparison function from the <code>String</code>
 	  module. We'll talk about why the comparator witness is
 	  important later in the chapter.</p>
-
 	<p>
 	  The call to <code>Map.empty</code> is also worth explaining,
 	  in that, unusually, it takes a first-class module as an
 	  argument.  The point of the first class module is to provide
 	  the comparison function that is required for building the
-	  map. We don't need the module again for functions
-	  like <code>Map.find</code> or <code>Map.add</code>, because
-	  the map itself a reference to the comparison function it
-	  uses.</p>
+	  map, along with an s-expression converter for generating
+	  useful error messages (we'll talk more about s-expressions
+	  in <a href="17-data-serialization.html"
+	  data-type="xref">Data Serialization with
+	  S-Expressions</a>). We don't need to provide the module
+	  again for functions like <code>Map.find</code>
+	  or <code>Map.add</code>, because the map itself contains a reference
+	  to the comparison function it uses.</p>
 
 
 	<p>
 	  Not every module can be used for creating maps, but the
-	  standard ones in Base are. In the next chapter, we'll show
-	  how to set up a new module in this way. </p>
+	  standard ones in Base are. In the next section, we'll show
+	  how you can set up a module your own so it can be used in
+	  this way. </p>
 
 	<section id="modules-and-comparators" data-type="sect2">
           <h2>Modules and Comparators</h2>
@@ -128,70 +132,125 @@
           <link rel="import" part="mc.2"
 		href="code/maps-and-hash-tables/main.mlt" />
 
-          <p>
-	    The comparator is only required for operations that create
-            maps from scratch. Operations that update an existing map
-            simply inherit the comparator of the map they start with,
-            as we say above with the use of <code>Map.find</code>.</p>
+	  <p>
+	    The type <code>Map.comparator</code> is actually an alias
+	    for a first-class module type, representing any module
+	    that matches the signature <code>Comparator.S</code>,
+	    shown below.</p>
+
+          <link rel="import" part="mc.2.1"
+		href="code/maps-and-hash-tables/main.mlt" />
+
+	  <p>
+	    Such a module needs to contain the type of the key itself,
+	    as well as the <code>comparator_witness</code> type, which
+	    serves as a type-level identifier of the comparison
+	    function in question, and finally, the concrete comparator
+	    itself, a value that contains the necessary comparison
+	    function.</p>
+
+	  <p>
+	    Modules from Base like <code>Int</code>
+	    and <code>String</code> already satisfy this
+	    interface. But what if you want to satisfy this interface
+	    with a new module? Consider, for example, the following
+	    type representing a book, for which we've written a
+	    comparison function and an s-expression serializer.</p>
+
+          <link rel="import" part="mc.2.2"
+		href="code/maps-and-hash-tables/main.mlt" />
+
+	  <p>
+	    This module has the basic functionality we need, but
+	    doesn't satisfy the <code>Comparator.S</code> interface,
+	    so we can't use it for creating a map, as you can see.</p>
+
+          <link rel="import" part="mc.2.3"
+		href="code/maps-and-hash-tables/main.mlt" />
+
+	  <p>
+	    In order to satisfy the interface, we need to use
+	    the <code>Comparator.Make</code> functor to extend the
+	    module. Here, we use a common idiom where we create a
+	    submodule, called <code>T</code> containing the basic
+	    functionality for the type in question, and then include
+	    both that module and one or more functors applied to the
+	    module to construct the desired result.</p>
+
+          <link rel="import" part="mc.2.4"
+		href="code/maps-and-hash-tables/main.mlt" />
+
+	  <p>
+	    With this module in hand, we can now build a set or a map
+	    using the type <code>Book.t</code>.</p>
+
+          <link rel="import" part="mc.2.5"
+		href="code/maps-and-hash-tables/main.mlt" />
+
+	  </section>
+	  <section id="why-comparator-witnesses" data-type="sect2">
+          <h2>Why do we need comparator witnesses?</h2>
 
           <p>
-	    Including the comparator in the type is important because
-            operations that work on multiple maps at the same time
-            often require that the maps share their comparison
-            function.  Consider, for
-            example, <code>Map.symmetric_diff</code>, which computes
-            the difference between two maps.</p>
+	    The comparator witness looks a little surprising at first,
+	    and it may not be obvious why it's there in the first
+	    place. The purpose of the comparison witness is to
+	    identify the comparison function being used at the type
+	    level, which is important because some of the operations
+	    on maps, in particular those that combine multiple maps,
+	    depend for their correctness on the fact that the
+	    different maps are using the same comparison function.</p>
+
+
+	  <p>
+	    Consider, for example, <code>Map.symmetric_diff</code>,
+	    which computes the difference between two maps.</p>
 
           <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="mc.3"/>
 
           <p>
 	    The type of <code>Map.symmetric_diff</code>, which
             follows, requires that the two maps it compares have the
-            same comparator type. Each comparator has a distinct
-            abstract type, so the type of a comparator identifies the
-            comparator uniquely.</p>
+            same comparator type, and therefore the same comparison
+            function.</p>
 
           <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="mc.4"/>
 
           <p>
-	    This constraint is important because the algorithm
-            that <code>Map.symmetric_diff</code> uses depends on the
-            fact that both maps have the same comparator; running it
-            on maps sorted in different ways would lead to garbled
-            results.</p>
-
-          <p>
-	    We can create a new comparator using
-            the <code>Comparator.Make</code> functor, which takes as
-            its input a module containing the type of the object to be
-            compared, sexp converter functions, and a comparison
-            function. The sexp converters are included in the
-            comparator to make it possible for users of the comparator
-            to generate better error messages. Here's an example:
-
-	    <idx>Sexplib package/sexp converter</idx></p>
+	    Without this constraint, we could
+	    run <code>Map.symmetric_diff</code> on maps that are
+	    sorted in different orders, which could lead to garbled
+            results. We can show how this works in practice by
+            creating two maps with the same key and data types, but
+            different comparison functions.  In the following, we do
+            this by minting a new module <code>Reverse</code>, which
+            represents strings sorted in the reverse of the usual
+            lexicographic order.
+	  </p>
 
           <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="mc.5"/>
 
           <p>
-	    As you can see in the following code,
-            both <code>Reverse</code> and <code>String</code> can be
+	    As you can see in the following, both <code>Reverse</code>
+	    and <code>String</code> can be
             used to create maps with a key type
             of <code>string</code>:</p>
 
           <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="mc.6"/>
 
           <p>
-	    <code>Map.min_elt</code> returns the key and value for
-            the smallest key in the map, which lets us see that these
-            two maps do indeed use different comparison functions:</p>
+	    <code>Map.min_elt</code> returns the key and value for the
+            smallest key in the map, which confirms that these two
+            maps do indeed use different comparison functions.</p>
 
           <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="mc.7"/>
 
           <p>
-	    Accordingly, if we try to use
-            <code>Map.symmetric_diff</code> on these two maps, we'll
-            get a compile-time error:</p>
+	    As such, running <code>Map.symmetric_diff</code> on these
+	    maps doesn't make any sense. Happily, the type system will
+            give us a compile-time error if we try, instead of
+            throwing an error at run time, or worse, silently
+            returning the wrong result.</p>
 
           <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="mc.8"/>
 	</section>
@@ -201,30 +260,29 @@
 
           <p>
 	    We don't need to generate specialized comparators for
-            every type we want to build a map on. We can instead use a
-            comparator based on OCaml's built-in polymorphic comparison
-            function, which was discussed in <a href="03-lists-and-patterns.html#lists-and-patterns" data-type="xref">Lists And Patterns</a>. This comparator is found in
-            the <code>Comparator.Poly</code> module, allowing us to
-            write:
+            every type we want to build a map on. We can instead build
+            a map based on OCaml's built-in polymorphic comparison
+            function, which was discussed
+            in <a href="03-lists-and-patterns.html#lists-and-patterns"
+            data-type="xref">Lists And Patterns</a>. Base currently
+            doesn't have a convenient function for minting maps based
+            on polymorphic compare, but Core_kernel does, as we can
+            see below.
 
 	    <idx>maps/polymorphic comparison in</idx>
-	    <idx>Comparator.Poly module</idx>
-	    <idx>polymorphic comparisons</idx></p>
-
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="14"/>
-
-          <p>
-	    Or, equivalently:</p>
-
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="15"/>
+	    <idx>polymorphic comparisons</idx>
+	  </p>
+          <link rel="import" part="pc.1"
+		href="code/maps-and-hash-tables/main.mlt" />
 
           <p>
-	    Note that maps based on the polymorphic comparator are
-            not equivalent to those based on the type-specific
-            comparators from the point of view of the type system.
-            Thus, the compiler rejects the following:</p>
+	    Note that maps based on the polymorphic comparator have
+	    different comparator witnesses than those based on the
+	    type-specific comparison function.  Thus, the compiler
+	    rejects the following:</p>
 
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="16"/>
+          <link rel="import" part="pc.2"
+		href="code/maps-and-hash-tables/main.mlt"/>
 
           <p>
 	    This is rejected for good reason: there's no guarantee
@@ -254,10 +312,10 @@
               function that works for most OCaml values and largely
               behaves as you would expect. For example,
               on <code>int</code>s and <code>float</code>s, it acts as
-              you would expect a numeric comparison function to
-              act. For simple containers like strings and lists and
-              arrays, it operates as a lexicographic comparison. And
-              except for values from outside of the OCaml heap and
+              you would expect a numeric comparison function to act,
+              and for simple containers like strings and lists and
+              arrays, it operates as a lexicographic comparison.
+              Except for values from outside of the OCaml heap and
               functions, it works on almost every OCaml type.</p>
 
             <p>

--- a/book/13-maps-and-hashtables.html
+++ b/book/13-maps-and-hashtables.html
@@ -79,7 +79,7 @@
 	  third type parameter, the <em>comparator witness</em>,
 	  requires some explaining. </p>
 
-	<p> 
+	<p>
 	  The comparator witness is used to indicate which comparison
 	  function was used to construct the map, rather than saying
 	  anything about concrete data stored in the map.  The
@@ -115,42 +115,34 @@
 	    on <code>digit_alist</code>, which was defined earlier in
 	    the chapter. </p>
 
-          <link rel="import" part="mc.1" 
+          <link rel="import" part="mc.1"
 		href="code/maps-and-hash-tables/main.mlt" />
 
-	  <p> 
+	  <p>
 	    The function <code>Map.of_alist_exn</code> constructs a
 	    map from a provided association list, throwing an
 	    exception if a key is used more than once.  Let's take a
 	    look at the type signature
 	    of <code>Map.of_alist_exn</code>.</p>
 
-          <link rel="import" part="mc.2" 
+          <link rel="import" part="mc.2"
 		href="code/maps-and-hash-tables/main.mlt" />
 
           <p>
-	    The comparator is only required for operations that
-            create maps from scratch. Operations that update an
-            existing map simply inherit the comparator of the map they
-            start with:</p>
-
-
-          <p>
-	    The type <code>Map.t</code> has three type parameters: one
-            for the key, one for the value, and one to identify the
-            comparator. Indeed, the type <code>'a Int.Map.t</code> is
-            just a type alias
-            for <code>(int,'a,Int.comparator_witness)
-            Map.t</code>.</p>
+	    The comparator is only required for operations that create
+            maps from scratch. Operations that update an existing map
+            simply inherit the comparator of the map they start with,
+            as we say above with the use of <code>Map.find</code>.</p>
 
           <p>
 	    Including the comparator in the type is important because
-            operations that work on multiple maps at the same time often
-            require that the maps share their comparison function.
-            Consider, for example, <code>Map.symmetric_diff</code>,
-            which computes the difference between two maps.</p>
+            operations that work on multiple maps at the same time
+            often require that the maps share their comparison
+            function.  Consider, for
+            example, <code>Map.symmetric_diff</code>, which computes
+            the difference between two maps.</p>
 
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="5"/>
+          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="mc.3"/>
 
           <p>
 	    The type of <code>Map.symmetric_diff</code>, which
@@ -159,27 +151,27 @@
             abstract type, so the type of a comparator identifies the
             comparator uniquely.</p>
 
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="6"/>
+          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="mc.4"/>
 
           <p>
 	    This constraint is important because the algorithm
-            that <code>Map.symmetric_diff</code> uses depends for its
-            correctness on the fact that both maps have the same
-            comparator.</p>
+            that <code>Map.symmetric_diff</code> uses depends on the
+            fact that both maps have the same comparator; running it
+            on maps sorted in different ways would lead to garbled
+            results.</p>
 
           <p>
-	    We can create a new comparator using the
-            <code>Comparator.Make</code> functor, which takes as its
-            input a module containing the type of the object to be
+	    We can create a new comparator using
+            the <code>Comparator.Make</code> functor, which takes as
+            its input a module containing the type of the object to be
             compared, sexp converter functions, and a comparison
             function. The sexp converters are included in the
             comparator to make it possible for users of the comparator
-            to generate better error messages. Here's an
-            example:
+            to generate better error messages. Here's an example:
 
 	    <idx>Sexplib package/sexp converter</idx></p>
 
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="7"/>
+          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="mc.5"/>
 
           <p>
 	    As you can see in the following code,
@@ -187,65 +179,21 @@
             used to create maps with a key type
             of <code>string</code>:</p>
 
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="8"/>
+          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="mc.6"/>
 
           <p>
 	    <code>Map.min_elt</code> returns the key and value for
             the smallest key in the map, which lets us see that these
             two maps do indeed use different comparison functions:</p>
 
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="9"/>
+          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="mc.7"/>
 
           <p>
 	    Accordingly, if we try to use
             <code>Map.symmetric_diff</code> on these two maps, we'll
             get a compile-time error:</p>
 
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="10"/>
-	</section>
-
-	<section id="trees" data-type="sect2">
-          <h2>Trees</h2>
-
-          <p>
-	    As we've discussed, maps carry within them the comparator
-            that they were created with. Sometimes, for space
-            efficiency reasons, you want a version of the map data
-            structure that doesn't include the comparator. You can get
-            such a representation with <code>Map.to_tree</code>, which
-            returns just the tree underlying the map, without the
-            comparator:
-
-	    <idx>Map module/Map.to_tree</idx>
-	    <idx>maps/tree structure</idx></p>
-
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="11"/>
-
-          <p>
-	    Even though a <code>Map.Tree.t</code> doesn't physically
-            include a comparator, it does include the comparator in its
-            type. This is what is known as a <em>phantom type</em>,
-            because it reflects something about the logic of the value
-            in question, even though it doesn't correspond to any
-            values directly represented in the underlying physical
-            structure of the value.</p>
-
-          <p>
-	    Since the comparator isn't included in the tree, we need
-            to provide the comparator explicitly when we, say, search
-            for a key, as shown below:</p>
-
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="12"/>
-
-          <p>
-	    The algorithm of <code>Map.Tree.find</code> depends on
-            the fact that it's using the same comparator when looking
-            up a value as you were when you stored it. That's the
-            invariant that the phantom type is there to enforce. As you
-            can see in the following example, using the wrong
-            comparator will lead to a type error:</p>
-
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="13"/>
+          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="mc.8"/>
 	</section>
 
 	<section id="the-polymorphic-comparator" data-type="sect2">
@@ -527,6 +475,51 @@
             <link rel="import" href="code/maps-and-hash-tables/phys_equal.rawscript"/>
           </aside>
 	</section>
+
+	<section id="trees" data-type="sect2">
+          <h2>Trees</h2>
+
+          <p>
+	    As we've discussed, maps carry within them the comparator
+            that they were created with. Sometimes, for space
+            efficiency reasons, you want a version of the map data
+            structure that doesn't include the comparator. You can get
+            such a representation with <code>Map.to_tree</code>, which
+            returns just the tree underlying the map, without the
+            comparator:
+
+	    <idx>Map module/Map.to_tree</idx>
+	    <idx>maps/tree structure</idx></p>
+
+          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="11"/>
+
+          <p>
+	    Even though a <code>Map.Tree.t</code> doesn't physically
+            include a comparator, it does include the comparator in its
+            type. This is what is known as a <em>phantom type</em>,
+            because it reflects something about the logic of the value
+            in question, even though it doesn't correspond to any
+            values directly represented in the underlying physical
+            structure of the value.</p>
+
+          <p>
+	    Since the comparator isn't included in the tree, we need
+            to provide the comparator explicitly when we, say, search
+            for a key, as shown below:</p>
+
+          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="12"/>
+
+          <p>
+	    The algorithm of <code>Map.Tree.find</code> depends on
+            the fact that it's using the same comparator when looking
+            up a value as you were when you stored it. That's the
+            invariant that the phantom type is there to enforce. As you
+            can see in the following example, using the wrong
+            comparator will lead to a type error:</p>
+
+          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="13"/>
+	</section>
+
       </section>
 
       <section id="hash-tables" data-type="sect1">

--- a/book/13-maps-and-hashtables.html
+++ b/book/13-maps-and-hashtables.html
@@ -53,9 +53,10 @@
 
 	<p>
 	  Let's consider an example of how one might use a map in
-	  practice. In <a href="04-files-modules-and-programs.html#files-modules-and-programs" data-type="xref">Files Modules And Programs</a>, we showed a
-	  module <code>Counter</code> for keeping frequency counts on a
-	  set of strings. Here's the interface:</p>
+	  practice. In <a href="04-files-modules-and-programs.html#files-modules-and-programs"
+	  data-type="xref">Files Modules And Programs</a>, we showed a
+	  module <code>Counter</code> for keeping frequency counts on
+	  a set of strings. Here's the interface:</p>
 
 	<link rel="import" href="code/files-modules-and-programs/freq-fast/counter.mli"/>
 
@@ -71,53 +72,61 @@
 	<link rel="import" href="code/files-modules-and-programs/freq-fast/counter.ml"/>
 
 	<p>
-	  Note that in some places the preceding code refers to
-	  <code>String.Map.t</code>, and in others <code>Map.t</code>.
-	  This has to do with the fact that maps are implemented as
-	  ordered binary trees, and as such, need a way of comparing
-	  keys.</p>
+	  Take a look at the definition of the type <code>t</code>
+	  above.  You'll see that the <code>Map.t</code> has three
+	  type parameter. The first two are what you might expect; one
+	  for the type of the key, and one for type of the data. The
+	  third type parameter, the <em>comparator witness</em>,
+	  requires some explaining. </p>
+
+	<p> 
+	  The comparator witness is used to indicate which comparison
+	  function was used to construct the map, rather than saying
+	  anything about concrete data stored in the map.  The
+	  type <code>String.comparator_witness</code> in particular
+	  indicates that this map was built with the default
+	  comparison function from the <code>String</code>
+	  module. We'll talk about why the comparator witness is
+	  important later in the chapter.</p>
 
 	<p>
-	  To deal with this, a map, once created, stores the
-	  necessary comparison function within the data structure.
-	  Thus, operations like <code>Map.find</code> or
-	  <code>Map.add</code> that access the contents of a map or
-	  create a new map from an existing one, do so by using the
-	  comparison function embedded within the map.</p>
+	  The call to <code>Map.empty</code> is also worth explaining,
+	  in that, unusually, it takes a first-class module as an
+	  argument.  The point of the first class module is to provide
+	  the comparison function that is required for building the
+	  map. We don't need the module again for functions
+	  like <code>Map.find</code> or <code>Map.add</code>, because
+	  the map itself a reference to the comparison function it
+	  uses.</p>
+
 
 	<p>
-	  But in order to get a map in the first place, you need to
-	  get your hands on the comparison function somehow. For this
-	  reason, modules like <code>String</code> contain a
-	  <code>Map</code> submodule that has values like
-	  <code>String.Map.empty</code> and
-	  <code>String.Map.of_alist</code> that are specialized to
-	  strings, and thus have access to a string comparison
-	  function. Such a <code>Map</code> submodule is included in
-	  every module that satisfies the <code>Comparable.S</code>
-	  interface from Core.</p>
+	  Not every module can be used for creating maps, but the
+	  standard ones in Base are. In the next chapter, we'll show
+	  how to set up a new module in this way. </p>
 
-	<section id="creating-maps-with-comparators" data-type="sect2">
-          <h2>Creating Maps with Comparators</h2>
+	<section id="modules-and-comparators" data-type="sect2">
+          <h2>Modules and Comparators</h2>
 
           <p>
-	    The specialized <code>Map</code> submodule is
-            convenient, but it's not the only way of creating a
-            <code>Map.t</code>. The information required to compare
-            values of a given type is wrapped up in a value called a
-            <em>comparator</em> that can be used to create maps using
-            the <code>Map</code> module directly:
+	    It's easy enough to create a map whose key type is
+	    represented by a module in Base.  Here, we'll create a map
+	    from digits to their English names, based
+	    on <code>digit_alist</code>, which was defined earlier in
+	    the chapter. </p>
 
-	    <idx>comparators, creating maps with</idx>
-	    <idx>Map module/Map.of_alist_exn</idx>
-	    <idx>maps/creating with comparators</idx></p>
+          <link rel="import" part="mc.1" 
+		href="code/maps-and-hash-tables/main.mlt" />
 
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="3"/>
+	  <p> 
+	    The function <code>Map.of_alist_exn</code> constructs a
+	    map from a provided association list, throwing an
+	    exception if a key is used more than once.  Let's take a
+	    look at the type signature
+	    of <code>Map.of_alist_exn</code>.</p>
 
-          <p>
-	    The preceding code uses <code>Map.of_alist_exn</code>,
-            which creates a map from an association list, throwing an
-            exception if there are duplicate keys in the list.</p>
+          <link rel="import" part="mc.2" 
+		href="code/maps-and-hash-tables/main.mlt" />
 
           <p>
 	    The comparator is only required for operations that
@@ -125,7 +134,6 @@
             existing map simply inherit the comparator of the map they
             start with:</p>
 
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="4"/>
 
           <p>
 	    The type <code>Map.t</code> has three type parameters: one
@@ -175,9 +183,9 @@
 
           <p>
 	    As you can see in the following code,
-            both <code>Reverse.comparator_witness</code>
-            and <code>String.comparator_witness</code> can be used to
-            create maps with a key type of <code>string</code>:</p>
+            both <code>Reverse</code> and <code>String</code> can be
+            used to create maps with a key type
+            of <code>string</code>:</p>
 
           <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="8"/>
 

--- a/book/13-maps-and-hashtables.html
+++ b/book/13-maps-and-hashtables.html
@@ -105,17 +105,39 @@
 
 	<p>
 	  Not every module can be used for creating maps, but the
-	  standard ones in Base are. In the next section, we'll show
+	  standard ones in <code>Base</code> are. Later in the chapter, we'll show
 	  how you can set up a module your own so it can be used in
 	  this way. </p>
+
+	<section id="sets" data-type="sect2">
+          <h2>Sets</h2>
+
+          <p>
+	    In addition to maps, <code>Base</code> also provides a set
+	    data type that's designed along similar lines. In some
+	    sense, sets are little more than maps where you ignore the
+	    data.  But while you could encode sets in terms of maps,
+	    it's more natural, and more efficient, to
+	    use <code>Base</code>'s specialized set type. Here's a
+	    simple example.  <idx>set types</idx></p>
+
+          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="17"/>
+
+          <p>
+	    In addition to the operators you would expect to have
+            for maps, sets support the traditional set operations,
+            including union, intersection, and set difference. And, as
+            with maps, we can create sets based on type-specific
+            comparators or on the polymorphic comparator.</p>
+	</section>
 
 	<section id="modules-and-comparators" data-type="sect2">
           <h2>Modules and Comparators</h2>
 
           <p>
-	    It's easy enough to create a map whose key type is
-	    represented by a module in Base.  Here, we'll create a map
-	    from digits to their English names, based
+	    It's easy enough to create a map or set based on a type
+	    represented by a module in <code>Base</code>.  Here, we'll
+	    create a map from digits to their English names, based
 	    on <code>digit_alist</code>, which was defined earlier in
 	    the chapter. </p>
 
@@ -150,7 +172,7 @@
 	    function.</p>
 
 	  <p>
-	    Modules from Base like <code>Int</code>
+	    Modules from <code>Base</code> like <code>Int</code>
 	    and <code>String</code> already satisfy this
 	    interface. But what if you want to satisfy this interface
 	    with a new module? Consider, for example, the following
@@ -174,15 +196,15 @@
 	    module. Here, we use a common idiom where we create a
 	    submodule, called <code>T</code> containing the basic
 	    functionality for the type in question, and then include
-	    both that module and one or more functors applied to the
-	    module to construct the desired result.</p>
+	    both that module and the result of applying a functor to
+	    that module.</p>
 
           <link rel="import" part="mc.2.4"
 		href="code/maps-and-hash-tables/main.mlt" />
 
 	  <p>
-	    With this module in hand, we can now build a set or a map
-	    using the type <code>Book.t</code>.</p>
+	    With this module in hand, we can now build a set using the
+	    type <code>Book.t</code>.</p>
 
           <link rel="import" part="mc.2.5"
 		href="code/maps-and-hash-tables/main.mlt" />
@@ -194,13 +216,12 @@
           <p>
 	    The comparator witness looks a little surprising at first,
 	    and it may not be obvious why it's there in the first
-	    place. The purpose of the comparison witness is to
-	    identify the comparison function being used at the type
-	    level, which is important because some of the operations
-	    on maps, in particular those that combine multiple maps,
-	    depend for their correctness on the fact that the
-	    different maps are using the same comparison function.</p>
-
+	    place. The purpose of the witness is to identify the
+	    comparison function being used. This is important because
+	    some of the operations on maps and sets, in particular
+	    those that combine multiple maps or sets together, depend
+	    for their correctness on the fact that the different maps
+	    are using the same comparison function.</p>
 
 	  <p>
 	    Consider, for example, <code>Map.symmetric_diff</code>,
@@ -264,9 +285,9 @@
             a map based on OCaml's built-in polymorphic comparison
             function, which was discussed
             in <a href="03-lists-and-patterns.html#lists-and-patterns"
-            data-type="xref">Lists And Patterns</a>. Base currently
+            data-type="xref">Lists And Patterns</a>. <code>Base</code> currently
             doesn't have a convenient function for minting maps based
-            on polymorphic compare, but Core_kernel does, as we can
+            on polymorphic compare, but <code>Core_kernel</code> does, as we can
             see below.
 
 	    <idx>maps/polymorphic comparison in</idx>
@@ -320,17 +341,17 @@
 
             <p>
 	      But sometimes, a structural comparison is not what you
-              want. Sets are a great example of this. Consider the
-              following two sets:</p>
+              want. Maps are actually a fine example of this. Consider
+              the following two maps.</p>
 
-            <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="18"/>
+            <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="ppc.1"/>
 
             <p>
 	      Logically, these two sets should be equal, and that's
-              the result that you get if you call
-              <code>Set.equal</code> on them:</p>
+              the result that you get if you
+              call <code>Map.equal</code> on them:</p>
 
-            <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="19"/>
+            <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="ppc.2"/>
 
             <p>
 	      But because the elements were added in different
@@ -339,20 +360,26 @@
               will conclude that they're different.</p>
 
             <p>
-	      Let's see what happens if we use polymorphic compare
-              to test for equality by way of the <code>=</code>
-              operator. Comparing the maps directly will fail at
-              runtime because the comparators stored within the sets
-              contain function values:</p>
+	      Let's see what happens if we use polymorphic compare to
+              test for equality. <code>Base</code> hides polymorphic comparison by
+              defaults, but it is available by opening
+              the <code>Poly</code> module, at which
+              point <code>=</code> is bound to polymorphic equality.
+              Comparing the maps directly will fail at runtime because
+              the comparators stored within the sets contain function
+              values:</p>
 
-            <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="20"/>
+            <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="ppc.3"/>
 
             <p>
-	      We can, however, use the function
-              <code>Set.to_tree</code> to expose the underlying tree
-              without the attached comparator:</p>
+	      We can, however, use the
+              function <code>Map.Using_comparator.to_tree</code> to
+              expose the underlying binary tree without the attached
+              comparator. This same issue comes up with other data
+              types, including sets, which we'll discuss later in the
+              chapter.</p>
 
-            <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="21"/>
+            <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="ppc.4"/>
 
             <p>
 	      This can cause real and quite subtle bugs. If, for
@@ -366,107 +393,37 @@
           </aside>
 	</section>
 
-	<section id="sets" data-type="sect2">
-          <h2>Sets</h2>
+	<section id="using-deriving" data-type="sect2">
+          <h2>Using <code>[@@deriving]</code></h2>
 
-          <p>
-	    Sometimes, instead of keeping track of a set of key/value
-            pairs, you just want to keep track of a set of keys. You
-            could representing a set of values by a map whose data
-            type is <code>unit</code>. But a more idiomatic (and
-            efficient) solution is to use Core's set type, which is
-            similar in design and spirit to the map type, while having
-            an API better tuned to working with sets and a lower
-            memory footprint. Here's a simple example:
-	    <idx>set types</idx></p>
+	  <p>
+	    Using maps and sets on a new type requires satisfying
+	    the <code>Comparator.S</code> interface, which in turn
+	    requires s-expression converters and comparison functions
+	    for the type in question. Writing such functions by hand
+	    is annoying and error prone, but there's a better
+	    way. <code>Base</code> comes along with a set of syntax
+	    extensions that automate these tasks away.</p>
 
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="17"/>
+	  <p>
+	    Let's return to an example from earlier in the chapter,
+	    where we created a type <code>Book.t</code> and set it up
+	    for use in creating maps and sets.</p>
 
-          <p>
-	    In addition to the operators you would expect to have
-            for maps, sets support the traditional set operations,
-            including union, intersection, and set difference. And, as
-            with maps, we can create sets based on type-specific
-            comparators or on the polymorphic comparator.</p>
-	</section>
+          <link rel="import" part="mc.2.4"
+		href="code/maps-and-hash-tables/main.mlt" />
 
-	<section id="satisfying-the-comparable.s-interface" data-type="sect2">
-          <h2>Satisfying the Comparable.S Interface</h2>
+	  <p>
+	    Much of the code here is devoted to creating a comparison
+	    function and s-expression converter for the
+	    type <code>Book.t</code>. But if we have the ppx_sexp_conv
+	    and ppx_compare syntax extensions enabled (both of which
+	    come with the omnibus ppx_jane package), then we can
+	    request that default implementations of these functions be
+	    created, as follows.</p>
 
-          <p>
-	    Core's <code>Comparable.S</code> interface includes a
-            lot of useful functionality, including support for working
-            with maps and sets. In particular,
-            <code>Comparable.S</code> requires the presence of the
-            <code>Map</code> and <code>Set</code> submodules, as well
-            as a comparator.
-
-	    <idx>interfaces/Comparable.S</idx>
-	    <idx>Comparable module/Comparable.Make</idx>
-	    <idx>Comparable module/Comparable.S</idx>
-	    <idx>maps/comparable.S interface</idx></p>
-
-          <p>
-	    <code>Comparable.S</code> is satisfied by most of the
-            types in Core, but the question arises of how to satisfy
-            the comparable interface for a new type that you design.
-            Certainly implementing all of the required functionality
-            from scratch would be an absurd amount of work.</p>
-
-          <p>
-	    The module <code>Comparable</code> contains a number of
-            functors to help you automate this task. The simplest one
-            of these is <code>Comparable.Make</code>, which takes as an
-            input any module that satisfies the following
-            interface:</p>
-
-          <link rel="import" href="code/maps-and-hash-tables/comparable.ml"/>
-
-          <p>
-	    In other words, it expects a type with a comparison
-            function, as well as functions for converting to and
-            from <em>s-expressions</em>. S-expressions are a
-            serialization format used commonly in Core and are
-            required here to enable better error messages. We'll
-            discuss s-expressions more
-            in <a href="17-data-serialization.html#data-serialization-with-s-expressions"
-            data-type="xref">Data Serialization With S
-            Expressions</a>, but in the meantime, we'll use
-            the <code>[@@deriving sexp]</code> annotation that comes
-            from the <code>ppx_sexp_conv</code> syntax extension.
-            This declaration kicks off the automatic generation of
-            s-expression conversion functions for the marked type.</p>
-
-          <p>
-	    The following example shows how this all fits together,
-            following the same basic pattern for using functors described
-            in <a href="09-functors.html#extending-modules" data-type="xref">Extending Modules</a>:</p>
-
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="22"/>
-
-          <p>
-	    We don't include the full response from the toplevel
-            because it is quite lengthy, but <code>Foo_and_bar</code>
-            does satisfy <code>Comparable.S</code>.</p>
-
-          <p>
-	    In the preceding code we wrote the comparison function by
-            hand, but this isn't strictly necessary. Core ships with a
-            syntax extension which will create a comparison function
-            from a type definition if you write <code>[@@deriving
-            compare]</code> after the type defintion.  We can rewrite
-            the previous example to use this extension</p>
-
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="23"/>
-
-          <p>
-	    The comparison function we get from <code>[@@deriving
-	    compare]</code> will call out to the comparison functions
-	    for its component types. As a result, the <code>foo</code>
-	    field will be compared
-	    using <code>Int.Set.compare</code>. This is different, and
-            saner than the structural comparison done by polymorphic
-            compare.</p>
+          <link rel="import" part="ud.1"
+		href="code/maps-and-hash-tables/main.mlt" />
 
           <p>
 	    If you want your comparison function that orders things in
@@ -475,16 +432,6 @@
             suitable for creating maps and sets with,
             then <code>[@@deriving compare]</code> is a good
             choice.</p>
-
-          <p>
-	    You can also satisfy the <code>Comparable.S</code>
-            interface using polymorphic compare:</p>
-
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="24"/>
-
-          <p>
-	    That said, for reasons we discussed earlier, polymorphic
-            compare should be used sparingly.</p>
 
           <aside data-type="sidebar">
             <h5>=, ==, and phys_equal</h5>

--- a/book/13-maps-and-hashtables.html
+++ b/book/13-maps-and-hashtables.html
@@ -489,9 +489,10 @@
             that they were created with. Sometimes, for space
             efficiency reasons, you want a version of the map data
             structure that doesn't include the comparator. You can get
-            such a representation with <code>Map.to_tree</code>, which
+            such a representation
+            with <code>Map.Using_comparator.to_tree</code>, which
             returns just the tree underlying the map, without the
-            comparator:
+            comparator.
 
 	    <idx>Map module/Map.to_tree</idx>
 	    <idx>maps/tree structure</idx></p>
@@ -499,7 +500,7 @@
           <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="11"/>
 
           <p>
-	    Even though a <code>Map.Tree.t</code> doesn't physically
+	    Even though the tree doesn't physically
             include a comparator, it does include the comparator in its
             type. This is what is known as a <em>phantom type</em>,
             because it reflects something about the logic of the value
@@ -532,11 +533,13 @@
 
 	<p>
 	  Hash tables are the imperative cousin of maps. We walked
-	  over a basic hash table implementation in <a href="08-imperative-programming.html#imperative-programming-1" data-type="xref">Imperative Programming 1</a>, so in this
-	  section we'll mostly discuss the pragmatics of Core's
-	  <code>Hashtbl</code> module. We'll cover this material more
-	  briefly than we did with maps because many of the concepts
-	  are shared.
+	  over a basic hash table implementation
+	  in <a href="08-imperative-programming.html#imperative-programming-1"
+	  data-type="xref">Imperative Programming 1</a>, so in this
+	  section we'll mostly discuss the pragmatics of
+	  Core's <code>Hashtbl</code> module. We'll cover this
+	  material more briefly than we did with maps because many of
+	  the concepts are shared.
 
 	  <idx>hash tables/basics of</idx></p>
 
@@ -563,25 +566,25 @@
           <p>
 	    The statement that hash tables provide constant-time
             access hides some complexities. First of all, any hash
-            table implementation, OCaml's included, needs to resize the
-            table when it gets too full. A resize requires allocating a
-            new backing array for the hash table and copying over all
-            entries, and so it is quite an expensive operation. That
-            means adding a new element to the table is only
-            <em>amortized</em> constant, which is to say, it's constant
-            on average over a long sequence of operations, but some of
-            the individual operations can be quite expensive.</p>
+            table implementation, OCaml's included, needs to resize
+            the table when it gets too full. A resize requires
+            allocating a new backing array for the hash table and
+            copying over all entries, and so it is quite an expensive
+            operation. That means adding a new element to the table is
+            only <em>amortized</em> constant, which is to say, it's
+            constant on average over a long sequence of operations,
+            but some of the individual operations can cost more.</p>
 
           <p>
-	    Another hidden cost of hash tables has to do with the
-            hash function you use. If you end up with a pathologically
-            bad hash function that hashes all of your data to the same
+	    Another hidden cost of hash tables has to do with the hash
+            function you use. If you end up with a pathologically bad
+            hash function that hashes all of your data to the same
             number, then all of your insertions will hash to the same
             underlying bucket, meaning you no longer get constant-time
-            access at all. Core's hash table implementation uses binary
-            trees for the hash-buckets, so this case only leads to
-            logarithmic time, rather than linear for a traditional hash
-            table.</p>
+            access at all. <code>Base</code>'s hash table
+            implementation uses binary trees for the hash-buckets, so
+            this case only leads to logarithmic time, rather than
+            linear for a traditional implementation.</p>
 
           <p>
 	    The logarithmic behavior of Core's hash tables in the
@@ -599,52 +602,64 @@
 	</div>
 
 	<p>
-	  When creating a hash table, we need to provide a value of
-	  type <em>hashable</em>, which includes among other things the
-	  function for hashing the key type. This is analogous to the
-	  comparator used for creating maps:</p>
+	  We create a hashtable in a way that's similar to how we
+	  create maps, by providing a first-class module from which
+	  the required operations for building a hashtable can be
+	  obtained.</p>
 
-	<link rel="import" href="code/maps-and-hash-tables/main.mlt" part="25"/>
-
-	<p>
-	  The <code>hashable</code> value is included as part of the
-	  <code>Hashable.S</code> interface, which is satisfied by most
-	  types in Core. The <code>Hashable.S</code> interface also
-	  includes a <code>Table</code> submodule which provides more
-	  convenient creation functions:</p>
-
-	<link rel="import" href="code/maps-and-hash-tables/main.mlt" part="26"/>
+	<link rel="import" part="ht.1"
+	      href="code/maps-and-hash-tables/main.mlt"/>
 
 	<p>
-	  There is also a polymorphic <code>hashable</code> value,
-	  corresponding to the polymorphic hash function provided by
-	  the OCaml runtime, for cases where you don't have a hash
-	  function for your specific type:</p>
+	  As with maps, most modules in Base are ready to be used for
+	  this purpose, but if you want to create a hash table from
+	  one of your own types, you need to do some work to prepare
+	  it. In order for a module to be suitable for passing
+	  to <code>Hashtbl.create</code>, it has to match the
+	  following interface.</p>
 
-	<link rel="import" href="code/maps-and-hash-tables/main.mlt" part="27"/>
-
-	<p>
-	  Or, equivalently:</p>
-
-	<link rel="import" href="code/maps-and-hash-tables/main.mlt" part="28"/>
+	<link rel="import" part="ht.2"
+	      href="code/maps-and-hash-tables/main.mlt"/>
 
 	<p>
-	  Note that, unlike the comparators used with maps and sets,
-	  hashables don't show up in the type of a
-	  <code>Hashtbl.t</code>. That's because hash tables don't have
-	  operations that operate on multiple hash tables that depend
-	  on those tables having the same hash function, in the way
-	  that <code>Map.symmetric_diff</code> and
-	  <code>Set.union</code> depend on their arguments using the
-	  same comparison function.
+	  Note that there's no equivalent to the comparator witness
+	  that came up for maps and sets. That's because the
+	  requirement for multiple objects to share a comparison
+	  function or a hash function mostly just doesn't come up for
+	  hash tables. That makes building a module suitable for use
+	  with a hash table simpler.</p>
 
-	  <idx>polymorphism/in hash functions</idx></p>
+	<link rel="import" part="ht.3"
+	      href="code/maps-and-hash-tables/main.mlt"/>
+
+	<p>
+	  You can also create a hashtable based on OCaml's
+	  polymorphic hash and comparison functions.</p>
+
+	<link rel="import" part="ht.4"
+	      href="code/maps-and-hash-tables/main.mlt" />
+
+	<p>
+	  This is highly convenient, but polymorphic comparison can
+	  behave in surprising ways, so it's generally best to avoid
+	  this for code where correctness matters.</p>
 
 	<div data-type="warning">
           <h1>Collisions with the Polymorphic Hash Function</h1>
 
+	  <p>
+	    The polymorphic hash function, like polymorphic compare,
+	    has problems that derive from the fact that it doesn't pay
+	    any attention to the type, just blindly walking down the
+	    structure of a data type and computing a hash from what it
+	    sees. That means that for data structures like maps and
+	    sets where equivalent instances can have different
+	    structures, it will do the wrong thing.</p>
+
           <p>
-	    OCaml's polymorphic hash function works by walking over
+	    But there's another problem with polymorphic hash, which
+	    is that it is prone to creating hash collisions.  OCaml's
+	    polymorphic hash function works by walking over
             the data structure it’s given using a breadth-first
             traversal that is bounded in the number of nodes it’s
             willing to traverse. By default, that bound is set at 10
@@ -654,55 +669,35 @@
 
           <p>
 	    The bound on the traversal means that the hash function
-            may ignore part of the data structure, and this can lead to
-            pathological <span class="keep-together">cases</span> where
-            every value you store has the same hash value. We'll
-            demonstrate this below, using the function
-            <code>List.range</code> to allocate lists of integers of
-            different length:</p>
+            may ignore part of the data structure, and this can lead
+            to pathological <span class="keep-together">cases</span>
+            where every value you store has the same hash value. We'll
+            demonstrate this below, using the
+            function <code>List.range</code> to allocate lists of
+            integers of different length:</p>
+
+	  <link rel="import" part="ph.1"
+		href="code/maps-and-hash-tables/main.mlt" />
+
+	  <p>
+	    As you can see, the hash function stops after the first 10
+	    elements. The same can happen with any large data structure,
+	    including records and arrays. When building hash functions
+	    over large custom data structures, it is generally a good
+	    idea to write one's own hash function, or to use the ones
+	    provided by <code>[@@deriving]</code>, which don't have
+	    this problem, as you can see below.</p>
+
+	  <link rel="import" part="ph.2"
+		href="code/maps-and-hash-tables/main.mlt" />
+
+	  <p>
+	    Note that rather than declaring a type and
+	    using <code>[@@deriving hash]</code> to invoke ppx_hash,
+	    we use <code>[%%hash]</code>, a shorthand for creating a
+	    hash function inline in an expression.</p>
+
 	</div>
-
-	<link rel="import" href="code/maps-and-hash-tables/main.mlt" part="29"/>
-
-	<p>
-	  As you can see, the hash function stops after the first 10
-	  elements. The same can happen with any large data structure,
-	  including records and arrays. When building hash functions
-	  over large custom data structures, it is generally a good
-	  idea to write one's own hash function.</p>
-
-	<section id="satisfying-the-hashable.s-interface" data-type="sect2">
-          <h2>Satisfying the Hashable.S Interface</h2>
-
-          <p>
-	    Most types in Core satisfy the <code>Hashable.S</code>
-            interface, but as with the <code>Comparable.S</code>
-            interface, the question remains of how one should satisfy
-            this interface when writing a new module. Again, the
-            answer is to use a functor to build the necessary
-            functionality; in this case, <code>Hashable.Make</code>,
-            using <code>[@@deriving hash]</code> to produce the hash
-            function.
-
-	    <idx>Hashable.Make</idx>
-	    <idx>interfaces/Hashable.S</idx>
-	    <idx>Hashable.S interface</idx>
-	    <idx>hash tables/satisfying Hashable.S interface</idx></p>
-
-          <link rel="import" href="code/maps-and-hash-tables/main.mlt" part="30"/>
-
-          <p>
-	    Note that in order to satisfy hashable, a key needs to
-            provide a comparison function, for equality checking, and
-            s-expression conversion, for generating useful errors.</p>
-
-          <p>
-	    There is currently no analogue of
-            <code>comparelib</code> for autogeneration of hash
-            functions, so you do need to either write the hash function
-            by hand, or use the built-in polymorphic hash function,
-            <code>Hashtbl.hash</code>.</p>
-	</section>
       </section>
 
       <section id="choosing-between-maps-and-hash-tables" data-type="sect1">

--- a/examples/code/fcm/query_handler.mlt
+++ b/examples/code/fcm/query_handler.mlt
@@ -135,7 +135,7 @@ Ok
   at log folders netboot run rpc tmp backups agentx rwho)
 |}];;
 List_dir.eval list_dir (sexp_of_string "yp");;
-[%%expect ocaml {|- : (Sexp.t, Error.t) result = Ok (binding)|}];;
+[%%expect.nondeterministic ocaml {|- : (Sexp.t, Error.t) result = Ok (binding)|}];;
 [@@@part "7"];;
 module type Query_handler_instance = sig
   module Query_handler : Query_handler

--- a/examples/code/files-modules-and-programs/freq-fast/counter.ml
+++ b/examples/code/files-modules-and-programs/freq-fast/counter.ml
@@ -1,6 +1,6 @@
 open Base
 
-type t = int Map.M(String).t
+type t = (string,int,String.comparator_witness) Map.t
 
 let empty = Map.empty (module String)
 

--- a/examples/code/maps-and-hash-tables/core_phys_equal.mlt
+++ b/examples/code/maps-and-hash-tables/core_phys_equal.mlt
@@ -7,12 +7,13 @@
 #silent false;;
 
 [@@@part "1"];;
-open Core_kernel;;
+open Base;;
 1 == 2 ;;
 [%%expect{|
 Characters 2-4:
-Warning 3: deprecated: Core_kernel.==
-[since 2014-10] Use [phys_equal]
+Warning 3: deprecated: Base.==
+[2016-09] this element comes from the stdlib distributed with OCaml.
+Use [phys_equal] instead.
 |};
 ocaml {|- : bool = false|}];;
 phys_equal 1 2 ;;

--- a/examples/code/maps-and-hash-tables/main.mlt
+++ b/examples/code/maps-and-hash-tables/main.mlt
@@ -260,21 +260,14 @@ Error: This expression has type (int, string, Int.comparator_witness) Map.t
 |}];;
 
 [@@@part "17"];;
-let dedup ~comparator l =
-  List.fold l ~init:(Set.empty ~comparator) ~f:Set.add
-  |> Set.to_list
-;;
-[%%expect{|
-Characters 58-68:
-Error: The function applied to this argument has type
-         ('a, 'b) Set.comparator -> ('a, 'b) Set.t
-This argument cannot be applied with label ~comparator
-|}];;
-dedup ~comparator:Int.comparator [8;3;2;3;7;8;10];;
-[%%expect{|
-Characters 0-5:
-Error: Unbound value dedup
-|}];;
+Set.of_list (module Int) [1;2;3] |> Set.to_list;;
+[%%expect ocaml {|- : int list = [1; 2; 3]|}];;
+Set.union
+  (Set.of_list (module Int) [1;2;3;2])
+  (Set.of_list (module Int) [3;5;1])
+|> Set.to_list;;
+[%%expect ocaml {|- : int list = [1; 2; 3; 5]|}];;
+
 
 [@@@part "ppc.1"];;
 let m1 = Map.of_alist_exn (module Int) [1, "one";2, "two"];;
@@ -294,6 +287,42 @@ Poly.(m1 = m2);;
 Poly.((Map.Using_comparator.to_tree m1) =
       (Map.Using_comparator.to_tree m2));;
 [%%expect ocaml {|- : bool = false|}];;
+
+[@@@part "ud.1"];;
+module Book = struct
+  module T = struct
+    type t = { title: string; isbn: string }
+    [@@deriving compare, sexp_of]
+  end
+  include T
+  include Comparator.Make(T)
+end;;
+[%%expect ocaml {|
+module Book :
+  sig
+    module T :
+      sig
+        type t = { title : string; isbn : string; }
+        val compare : t -> t -> int
+        val sexp_of_t : t -> Sexp.t
+      end
+    type t = T.t = { title : string; isbn : string; }
+    val compare : t -> t -> int
+    val sexp_of_t : t -> Sexp.t
+    type comparator_witness = Base__Comparator.Make(T).comparator_witness
+    val comparator : (t, comparator_witness) Comparator.t
+  end
+|}];;
+
+
+
+
+
+
+
+
+
+
 
 [@@@part "22"];;
 module Foo_and_bar : sig

--- a/examples/code/maps-and-hash-tables/main.mlt
+++ b/examples/code/maps-and-hash-tables/main.mlt
@@ -43,6 +43,101 @@ Map.of_alist_exn;;
 <fun>
 |}];;
 
+[@@@part "mc.2.1"];;
+#typeof "Comparator.S";;
+[%%expect.nondeterministic{|
+module type Base.Comparator.S =
+  sig
+    type t
+    type comparator_witness
+    val comparator : (t, comparator_witness) Base.Comparator.t
+  end
+|}];;
+
+[@@@part "mc.2.2"];;
+module Book = struct
+
+  type t = { title: string; isbn: string }
+
+  let compare t1 t2 =
+    let cmp_title = String.compare t1.title t2.title in
+    if cmp_title <> 0 then cmp_title
+    else String.compare t1.isbn t2.isbn
+
+  let sexp_of_t t : Sexp.t =
+    List [ Atom t.title; Atom t.isbn ]
+end;;
+[%%expect ocaml {|
+module Book :
+  sig
+    type t = { title : string; isbn : string; }
+    val compare : t -> t -> int
+    val sexp_of_t : t -> Sexp.t
+  end
+|}];;
+
+[@@@part "mc.2.3"];;
+Map.empty (module Book);;
+[%%expect{|
+Characters 18-22:
+Error: Signature mismatch:
+       ...
+       The value `comparator' is required but not provided
+       File "src/comparator.mli", line 21, characters 2-53:
+         Expected declaration
+       The type `comparator_witness' is required but not provided
+       File "src/comparator.mli", line 20, characters 2-25:
+         Expected declaration
+|}];;
+
+[@@@part "mc.2.4"];;
+module Book = struct
+  module T = struct
+
+    type t = { title: string; isbn: string }
+
+    let compare t1 t2 =
+      let cmp_title = String.compare t1.title t2.title in
+      if cmp_title <> 0 then cmp_title
+      else String.compare t1.isbn t2.isbn
+
+    let sexp_of_t t : Sexp.t =
+      List [ Atom t.title; Atom t.isbn ]
+
+  end
+  include T
+  include Comparator.Make(T)
+end;;
+[%%expect ocaml {|
+module Book :
+  sig
+    module T :
+      sig
+        type t = { title : string; isbn : string; }
+        val compare : t -> t -> int
+        val sexp_of_t : t -> Sexp.t
+      end
+    type t = T.t = { title : string; isbn : string; }
+    val compare : t -> t -> int
+    val sexp_of_t : t -> Sexp.t
+    type comparator_witness = Base__Comparator.Make(T).comparator_witness
+    val comparator : (t, comparator_witness) Comparator.t
+  end
+|}];;
+
+[@@@part "mc.2.5"];;
+let some_programming_books =
+  Set.of_list (module Book)
+    [ { title = "Real World OCaml"
+      ; isbn = "978-1449323912" }
+    ; { title = "Structure and Interpretation of Computer Programs"
+      ; isbn = "978-0262510875" }
+    ; { title = "The C Programming Language"
+      ; isbn = "978-0131101630" } ];;
+[%%expect ocaml {|
+val some_programming_books : (Book.t, Book.comparator_witness) Set.t =
+  <abstr>
+|}];;
 
 [@@@part "mc.3"];;
 let left = Map.of_alist_exn (module String) ["foo",1; "bar",3; "snoo",0];;
@@ -146,15 +241,11 @@ Error: This expression has type
          Reverse.comparator_witness 
 |}];;
 
-[@@@part "14"];;
-Map.Using_comparator.of_alist_exn ~comparator:Comparator.Poly.comparator digit_alist;;
-[%%expect ocaml {|- : (int, string, Comparator.Poly.comparator_witness) Map.t = <abstr>|}];;
-
-[@@@part "15"];;
+[@@@part "pc.1"];;
 Core_kernel.Map.Poly.of_alist_exn digit_alist;;
 [%%expect ocaml {|- : (int, string) Core_kernel.Map.Poly.t = <abstr>|}];;
 
-[@@@part "16"];;
+[@@@part "pc.2"];;
 Map.symmetric_diff
   (Core_kernel.Map.Poly.singleton 3 "three")
   (Map.singleton (module Int) 3 "four" )
@@ -185,26 +276,23 @@ Characters 0-5:
 Error: Unbound value dedup
 |}];;
 
-[@@@part "18"];;
-let s1 = Set.of_list (module Int) [1;2];;
-[%%expect ocaml {|val s1 : (int, Int.comparator_witness) Set.t = <abstr>|}];;
-let s2 = Set.of_list (module Int) [2;1];;
-[%%expect ocaml {|val s2 : (int, Int.comparator_witness) Set.t = <abstr>|}];;
+[@@@part "ppc.1"];;
+let m1 = Map.of_alist_exn (module Int) [1, "one";2, "two"];;
+[%%expect ocaml {|val m1 : (int, string, Int.comparator_witness) Map.t = <abstr>|}];;
+let m2 = Map.of_alist_exn (module Int) [2, "two";1, "one"];;
+[%%expect ocaml {|val m2 : (int, string, Int.comparator_witness) Map.t = <abstr>|}];;
 
-[@@@part "19"];;
-Set.equal s1 s2;;
+[@@@part "ppc.2"];;
+Map.equal String.equal m1 m2;;
 [%%expect ocaml {|- : bool = true|}];;
 
-[@@@part "20"];;
-s1 = s2;;
-[%%expect{|
-Characters 0-2:
-Error: This expression has type (int, Int.comparator_witness) Set.t
-       but an expression was expected of type int
-|}];;
+[@@@part "ppc.3"];;
+Poly.(m1 = m2);;
+[%%expect{|Exception: (Invalid_argument "compare: functional value").|}];;
 
-[@@@part "21"];;
-Poly.(=) (Set.Using_comparator.to_tree s1) (Set.Using_comparator.to_tree s2);;
+[@@@part "ppc.4"];;
+Poly.((Map.Using_comparator.to_tree m1) =
+      (Map.Using_comparator.to_tree m2));;
 [%%expect ocaml {|- : bool = false|}];;
 
 [@@@part "22"];;

--- a/examples/code/maps-and-hash-tables/main.mlt
+++ b/examples/code/maps-and-hash-tables/main.mlt
@@ -45,7 +45,7 @@ Map.of_alist_exn;;
 
 [@@@part "mc.2.1"];;
 #typeof "Comparator.S";;
-[%%expect.nondeterministic{|
+[%%expect.nondeterministic ocaml {|
 module type Base.Comparator.S =
   sig
     type t
@@ -315,179 +315,70 @@ module Book :
 |}];;
 
 
-
-
-
-
-
-
-
-
-
-[@@@part "22"];;
-module Foo_and_bar : sig
-  type t = { foo: Set.M(Int).t; bar: string }
-  include Comparable.S with type t := t
-end = struct
-  module T = struct
-    type t = { foo: Set.M(Int).t; bar: string } [@@deriving sexp]
-    let compare t1 t2 =
-      let c = Set.compare_direct t1.foo t2.foo in
-      if c <> 0 then c else String.compare t1.bar t2.bar
-  end
-  include T
-  include Comparable.Make(T)
-end;;
-[%%expect ocaml {|
-module Foo_and_bar :
-  sig
-    type t = { foo : Base.Set.M(Base.Int).t; bar : string; }
-    val ( >= ) : t -> t -> bool
-    val ( <= ) : t -> t -> bool
-    val ( = ) : t -> t -> bool
-    val ( > ) : t -> t -> bool
-    val ( < ) : t -> t -> bool
-    val ( <> ) : t -> t -> bool
-    val equal : t -> t -> bool
-    val compare : t -> t -> int
-    val min : t -> t -> t
-    val max : t -> t -> t
-    val ascending : t -> t -> int
-    val descending : t -> t -> int
-    val between : t -> low:t -> high:t -> bool
-    val clamp_exn : t -> min:t -> max:t -> t
-    val clamp : t -> min:t -> max:t -> t Base__.Or_error.t
-    type comparator_witness
-    val comparator : (t, comparator_witness) Comparator.t
-    val validate_lbound : min:t Core_kernel._maybe_bound -> t Validate.check
-    val validate_ubound : max:t Core_kernel._maybe_bound -> t Validate.check
-    val validate_bound :
-      min:t Core_kernel._maybe_bound ->
-      max:t Core_kernel._maybe_bound -> t Validate.check
-  end
-|}];;
-
-[@@@part "23"];;
-module Foo_and_bar : sig
-  type t = { foo: Set.M(Int).t; bar: string }
-  include Comparable.S with type t := t
-end = struct
-  module T = struct
-    type t = { foo: Set.M(Int).t; bar: string } [@@deriving sexp, compare]
-  end
-  include T
-  include Comparable.Make(T)
-end;;
-[%%expect ocaml {|
-module Foo_and_bar :
-  sig
-    type t = { foo : Base.Set.M(Base.Int).t; bar : string; }
-    val ( >= ) : t -> t -> bool
-    val ( <= ) : t -> t -> bool
-    val ( = ) : t -> t -> bool
-    val ( > ) : t -> t -> bool
-    val ( < ) : t -> t -> bool
-    val ( <> ) : t -> t -> bool
-    val equal : t -> t -> bool
-    val compare : t -> t -> int
-    val min : t -> t -> t
-    val max : t -> t -> t
-    val ascending : t -> t -> int
-    val descending : t -> t -> int
-    val between : t -> low:t -> high:t -> bool
-    val clamp_exn : t -> min:t -> max:t -> t
-    val clamp : t -> min:t -> max:t -> t Base__.Or_error.t
-    type comparator_witness
-    val comparator : (t, comparator_witness) Comparator.t
-    val validate_lbound : min:t Core_kernel._maybe_bound -> t Validate.check
-    val validate_ubound : max:t Core_kernel._maybe_bound -> t Validate.check
-    val validate_bound :
-      min:t Core_kernel._maybe_bound ->
-      max:t Core_kernel._maybe_bound -> t Validate.check
-  end
-|}];;
-
-[@@@part "24"];;
-module Foo_and_bar : sig
-  type t = { foo: int; bar: string }
-  include Comparable.S with type t := t
-end = struct
-  module T = struct
-    type t = { foo: int; bar: string } [@@deriving sexp]
-  end
-  include T
-  include Comparable.Poly(T)
-end;;
-[%%expect ocaml {|
-module Foo_and_bar :
-  sig
-    type t = { foo : int; bar : string; }
-    val ( >= ) : t -> t -> bool
-    val ( <= ) : t -> t -> bool
-    val ( = ) : t -> t -> bool
-    val ( > ) : t -> t -> bool
-    val ( < ) : t -> t -> bool
-    val ( <> ) : t -> t -> bool
-    val equal : t -> t -> bool
-    val compare : t -> t -> int
-...
-  end
-|}];;
-
-[@@@part "25"];;
-let table = Hashtbl.create ~hashable:String.hashable ();;
-[%%expect{|
-Characters 37-52:
-Error: The function applied to this argument has type
-         ?growth_allowed:bool -> ?size:int -> unit -> ('a, 'b) Hashtbl.t
-This argument cannot be applied with label ~hashable
-|}];;
-Hashtbl.set table ~key:"three" ~data:3;;
-[%%expect{|
-Characters 12-17:
-Error: Unbound value table
-|}];;
-Hashtbl.find table "three";;
-[%%expect{|
-Characters 13-18:
-Error: Unbound value table
-|}];;
-
-[@@@part "26"];;
+[@@@part "ht.1"];;
 let table = Hashtbl.create (module String) ();;
 [%%expect ocaml {|val table : (string, '_weak1) Hashtbl.t = <abstr>|}];;
+Hashtbl.set table ~key:"three" ~data:3;;
+[%%expect ocaml {|- : unit = ()|}];;
+Hashtbl.find table "three";;
+[%%expect ocaml {|- : int option = Some 3|}];;
 
-[@@@part "27"];;
-let table = Hashtbl.Poly.create ();;
-[%%expect ocaml {|val table : ('_weak2, '_weak3) Hashtbl.t = <abstr>|}];;
 
-[@@@part "28"];;
-let table = Hashtbl.Poly.create ();;
-[%%expect ocaml {|val table : ('_weak4, '_weak5) Hashtbl.t = <abstr>|}];;
-
-[@@@part "29"];;
-Caml.Hashtbl.hash (List.range 0 9);;
-[%%expect ocaml {|- : int = 209331808|}];;
-Caml.Hashtbl.hash (List.range 0 10);;
-[%%expect ocaml {|- : int = 182325193|}];;
-Caml.Hashtbl.hash (List.range 0 11);;
-[%%expect ocaml {|- : int = 182325193|}];;
-Caml.Hashtbl.hash (List.range 0 100);;
-[%%expect ocaml {|- : int = 182325193|}];;
-
-[@@@part "30"];;
-module Foo_and_bar : sig
-  type t = { foo: int; bar: string }
-  include Hashable.S with type t := t
-end = struct
-  module T = struct
-    type t = { foo: int; bar: string } [@@deriving sexp, compare, hash]
+[@@@part "ht.2"];;
+#typeof "Hashtbl_intf.Key";;
+[%%expect.nondeterministic ocaml {|
+module type Base.Hashtbl_intf.Key =
+  sig
+    type t
+    val compare : t -> t -> Base.int
+    val sexp_of_t : t -> Base.Sexp.t
+    val hash : t -> Base.int
   end
-  include T
-  include Hashable.Make(T)
-end;;
-[%%expect{|
-Characters 233-246:
-Error: Unbound module Hashable
-Hint: Did you mean Hashtbl or Hashtbl?
 |}];;
+
+[@@@part "ht.3"];;
+module Book = struct
+  type t = { title: string; isbn: string }
+  [@@deriving compare, sexp_of, hash]
+end;;
+[%%expect ocaml {|
+module Book :
+  sig
+    type t = { title : string; isbn : string; }
+    val compare : t -> t -> int
+    val sexp_of_t : t -> Sexp.t
+    val hash_fold_t : Hash.state -> t -> Hash.state
+    val hash : t -> int
+  end
+|}];;
+let table = Hashtbl.create (module Book) ();;
+[%%expect ocaml {|val table : (Book.t, '_weak2) Hashtbl.t = <abstr>|}];;
+
+[@@@part "ht.4"];;
+let table = Hashtbl.Poly.create ();;
+[%%expect ocaml {|val table : ('_weak3, '_weak4) Hashtbl.t = <abstr>|}];;
+Hashtbl.set table ~key:("foo",3,[1;2;3]) ~data:"random data!";;
+[%%expect ocaml {|- : unit = ()|}];;
+Hashtbl.find table ("foo",3,[1;2;3]);;
+[%%expect ocaml {|- : string option = Some "random data!"|}];;
+
+
+[@@@part "ph.1"];;
+Hashtbl.Poly.hashable.hash (List.range 0 9);;
+[%%expect ocaml {|- : int = 209331808|}];;
+Hashtbl.Poly.hashable.hash (List.range 0 10);;
+[%%expect ocaml {|- : int = 182325193|}];;
+Hashtbl.Poly.hashable.hash (List.range 0 11);;
+[%%expect ocaml {|- : int = 182325193|}];;
+Hashtbl.Poly.hashable.hash (List.range 0 100);;
+[%%expect ocaml {|- : int = 182325193|}];;
+
+[@@@part "ph.2"];;
+[%hash: int list] (List.range 0 9);;
+[%%expect ocaml {|- : int = 999007935|}];;
+[%hash: int list] (List.range 0 10);;
+[%%expect ocaml {|- : int = 195154657|}];;
+[%hash: int list] (List.range 0 11);;
+[%%expect ocaml {|- : int = 527899773|}];;
+[%hash: int list] (List.range 0 100);;
+[%%expect ocaml {|- : int = 594983280|}];;

--- a/examples/code/maps-and-hash-tables/main.mlt
+++ b/examples/code/maps-and-hash-tables/main.mlt
@@ -7,7 +7,7 @@
 #silent false;;
 
 [@@@part "1"];;
-open Core_kernel;;
+open Base;;
 let digit_alist =
   [ 0, "zero"; 1, "one"; 2, "two"  ; 3, "three"; 4, "four"
   ; 5, "five"; 6, "six"; 7, "seven"; 8, "eight"; 9, "nine" ]
@@ -30,35 +30,23 @@ List.Assoc.add ~equal:Int.equal digit_alist 0 "zilch";;
  (5, "five"); (6, "six"); (7, "seven"); (8, "eight"); (9, "nine")]
 |}];;
 
-[@@@part "3"];;
-let digit_map = Map.of_alist_exn digit_alist ~comparator:Int.comparator;;
-[%%expect{|
-Characters 57-71:
-Error: The function applied to this argument has type
-         ('a * 'b) list -> ('a, 'b, 'c) Map.t
-This argument cannot be applied with label ~comparator
-|}];;
+[@@@part "mc.1"];;
+let digit_map = Map.of_alist_exn (module Int) digit_alist;;
+[%%expect ocaml {|val digit_map : (int, string, Int.comparator_witness) Map.t = <abstr>|}];;
 Map.find digit_map 3;;
-[%%expect{|
-Characters 9-18:
-Error: Unbound value digit_map
-|}];;
+[%%expect ocaml {|- : string option = Some "three"|}];;
 
-[@@@part "4"];;
-let zilch_map = Map.add digit_map ~key:0 ~data:"zilch";;
-[%%expect{|
-Characters 16-23:
-Warning 3: deprecated: Core_kernel.Map.add
-[since 2017-11] Use [set] instead
-Characters 24-33:
-Error: Unbound value digit_map
+[@@@part "mc.2"];;
+Map.of_alist_exn;;
+[%%expect ocaml {|
+- : ('a, 'cmp) Map.comparator -> ('a * 'b) list -> ('a, 'b, 'cmp) Map.t =
+<fun>
 |}];;
-
 [@@@part "5"];;
-let left = String.Map.of_alist_exn ["foo",1; "bar",3; "snoo",0];;
-[%%expect ocaml {|val left : int String.Map.t = <abstr>|}];;
-let right = String.Map.of_alist_exn ["foo",0; "snoo",0];;
-[%%expect ocaml {|val right : int String.Map.t = <abstr>|}];;
+let left = Map.of_alist_exn (module String) ["foo",1; "bar",3; "snoo",0];;
+[%%expect ocaml {|val left : (string, int, String.comparator_witness) Map.t = <abstr>|}];;
+let right = Map.of_alist_exn (module String) ["foo",0; "snoo",0];;
+[%%expect ocaml {|val right : (string, int, String.comparator_witness) Map.t = <abstr>|}];;
 Map.symmetric_diff ~data_equal:Int.equal left right |> Sequence.to_list;;
 [%%expect ocaml {|
 - : (string, int) Map.Symmetric_diff_element.t list =
@@ -76,100 +64,102 @@ Map.symmetric_diff;;
 |}];;
 
 [@@@part "7"];;
-module Reverse = Comparator.Make(struct
+module Reverse = struct
+  module T = struct
     type t = string
     let sexp_of_t = String.sexp_of_t
     let t_of_sexp = String.t_of_sexp
     let compare x y = String.compare y x
-  end);;
+  end
+  include T
+  include Comparator.Make(T)
+end;;
 [%%expect ocaml {|
 module Reverse :
   sig
-    type comparator_witness
-    val comparator : (string, comparator_witness) Comparator.t
+    module T :
+      sig
+        type t = string
+        val sexp_of_t : t -> Sexp.t
+        val t_of_sexp : Sexp.t -> t
+        val compare : t -> t -> int
+      end
+    type t = string
+    val sexp_of_t : t -> Sexp.t
+    val t_of_sexp : Sexp.t -> t
+    val compare : t -> t -> int
+    type comparator_witness = Base__Comparator.Make(T).comparator_witness
+    val comparator : (t, comparator_witness) Comparator.t
   end
 |}];;
 
 [@@@part "8"];;
 let alist = ["foo", 0; "snoo", 3];;
 [%%expect ocaml {|val alist : (string * int) list = [("foo", 0); ("snoo", 3)]|}];;
-let ord_map = Map.of_alist_exn ~comparator:String.comparator alist;;
-[%%expect{|
-Characters 43-60:
-Error: The function applied to this argument has type
-         ('a * 'b) list -> ('a, 'b, 'c) Map.t
-This argument cannot be applied with label ~comparator
-|}];;
-let rev_map = Map.of_alist_exn ~comparator:Reverse.comparator alist;;
-[%%expect{|
-Characters 43-61:
-Error: The function applied to this argument has type
-         ('a * 'b) list -> ('a, 'b, 'c) Map.t
-This argument cannot be applied with label ~comparator
-|}];;
+let ord_map = Map.of_alist_exn (module String) alist;;
+[%%expect ocaml {|val ord_map : (string, int, String.comparator_witness) Map.t = <abstr>|}];;
+let rev_map = Map.of_alist_exn (module Reverse) alist;;
+[%%expect ocaml {|val rev_map : (string, int, Reverse.comparator_witness) Map.t = <abstr>|}];;
 
 [@@@part "9"];;
 Map.min_elt ord_map;;
-[%%expect{|
-Characters 12-19:
-Error: Unbound value ord_map
-|}];;
+[%%expect ocaml {|- : (string * int) option = Some ("foo", 0)|}];;
 Map.min_elt rev_map;;
-[%%expect{|
-Characters 12-19:
-Error: Unbound value rev_map
-|}];;
+[%%expect ocaml {|- : (string * int) option = Some ("snoo", 3)|}];;
 
 [@@@part "10"];;
 Map.symmetric_diff ord_map rev_map;;
 [%%expect{|
-Characters 19-26:
-Error: Unbound value ord_map
+Characters 27-34:
+Error: This expression has type
+         (string, int, Reverse.comparator_witness) Map.t
+       but an expression was expected of type
+         (string, int, String.comparator_witness) Map.t
+       Type Reverse.comparator_witness is not compatible with type
+         String.comparator_witness 
 |}];;
 
 [@@@part "11"];;
-let ord_tree = Map.to_tree ord_map;;
-[%%expect{|
-Characters 27-34:
-Error: Unbound value ord_map
+let ord_tree = Map.Using_comparator.to_tree ord_map;;
+[%%expect ocaml {|
+val ord_tree :
+  (string, int, String.comparator_witness) Map.Using_comparator.Tree.t =
+  <abstr>
 |}];;
 
 [@@@part "12"];;
-Map.Tree.find ~comparator:String.comparator ord_tree "snoo";;
-[%%expect{|
-Characters 44-52:
-Error: Unbound value ord_tree
-|}];;
+Map.Using_comparator.Tree.find ~comparator:String.comparator ord_tree "snoo";;
+[%%expect ocaml {|- : int option = Some 3|}];;
 
 [@@@part "13"];;
-Map.Tree.find ~comparator:Reverse.comparator ord_tree "snoo";;
+Map.Using_comparator.Tree.find ~comparator:Reverse.comparator ord_tree "snoo";;
 [%%expect{|
-Characters 45-53:
-Error: Unbound value ord_tree
+Characters 62-70:
+Error: This expression has type
+         (string, int, String.comparator_witness) Map.Using_comparator.Tree.t
+       but an expression was expected of type
+         (string, int, Reverse.comparator_witness)
+         Map.Using_comparator.Tree.t
+       Type String.comparator_witness is not compatible with type
+         Reverse.comparator_witness 
 |}];;
 
 [@@@part "14"];;
-Map.of_alist_exn ~comparator:Comparator.Poly.comparator digit_alist;;
-[%%expect{|
-Characters 29-55:
-Error: The function applied to this argument has type
-         ('a * 'b) list -> ('a, 'b, 'c) Map.t
-This argument cannot be applied with label ~comparator
-|}];;
+Map.Using_comparator.of_alist_exn ~comparator:Comparator.Poly.comparator digit_alist;;
+[%%expect ocaml {|- : (int, string, Comparator.Poly.comparator_witness) Map.t = <abstr>|}];;
 
 [@@@part "15"];;
-Map.Poly.of_alist_exn digit_alist;;
-[%%expect ocaml {|- : (int, string) Map.Poly.t = <abstr>|}];;
+Core_kernel.Map.Poly.of_alist_exn digit_alist;;
+[%%expect ocaml {|- : (int, string) Core_kernel.Map.Poly.t = <abstr>|}];;
 
 [@@@part "16"];;
 Map.symmetric_diff
-  (Map.Poly.singleton 3 "three")
-  (Int.Map.singleton  3 "four" )
+  (Core_kernel.Map.Poly.singleton 3 "three")
+  (Map.singleton (module Int) 3 "four" )
 ;;
 [%%expect{|
-Characters 54-84:
-Error: This expression has type
-         string Int.Map.t = (int, string, Int.comparator_witness) Map.t
+Characters 66-104:
+Error: This expression has type (int, string, Int.comparator_witness) Map.t
        but an expression was expected of type
          (int, string, Comparator.Poly.comparator_witness) Map.t
        Type Int.comparator_witness is not compatible with type
@@ -194,10 +184,10 @@ Error: Unbound value dedup
 |}];;
 
 [@@@part "18"];;
-let s1 = Int.Set.of_list [1;2];;
-[%%expect ocaml {|val s1 : Int.Set.t = <abstr>|}];;
-let s2 = Int.Set.of_list [2;1];;
-[%%expect ocaml {|val s2 : Int.Set.t = <abstr>|}];;
+let s1 = Set.of_list (module Int) [1;2];;
+[%%expect ocaml {|val s1 : (int, Int.comparator_witness) Set.t = <abstr>|}];;
+let s2 = Set.of_list (module Int) [2;1];;
+[%%expect ocaml {|val s2 : (int, Int.comparator_witness) Set.t = <abstr>|}];;
 
 [@@@part "19"];;
 Set.equal s1 s2;;
@@ -205,21 +195,25 @@ Set.equal s1 s2;;
 
 [@@@part "20"];;
 s1 = s2;;
-[%%expect{|Exception: (Invalid_argument "compare: functional value").|}];;
+[%%expect{|
+Characters 0-2:
+Error: This expression has type (int, Int.comparator_witness) Set.t
+       but an expression was expected of type int
+|}];;
 
 [@@@part "21"];;
-Set.to_tree s1 = Set.to_tree s2;;
+Poly.(=) (Set.Using_comparator.to_tree s1) (Set.Using_comparator.to_tree s2);;
 [%%expect ocaml {|- : bool = false|}];;
 
 [@@@part "22"];;
 module Foo_and_bar : sig
-  type t = { foo: Int.Set.t; bar: string }
+  type t = { foo: Set.M(Int).t; bar: string }
   include Comparable.S with type t := t
 end = struct
   module T = struct
-    type t = { foo: Int.Set.t; bar: string } [@@deriving sexp]
+    type t = { foo: Set.M(Int).t; bar: string } [@@deriving sexp]
     let compare t1 t2 =
-      let c = Int.Set.compare t1.foo t2.foo in
+      let c = Set.compare_direct t1.foo t2.foo in
       if c <> 0 then c else String.compare t1.bar t2.bar
   end
   include T
@@ -228,7 +222,7 @@ end;;
 [%%expect ocaml {|
 module Foo_and_bar :
   sig
-    type t = { foo : Int.Set.t; bar : string; }
+    type t = { foo : Base.Set.M(Base.Int).t; bar : string; }
     val ( >= ) : t -> t -> bool
     val ( <= ) : t -> t -> bool
     val ( = ) : t -> t -> bool
@@ -237,33 +231,30 @@ module Foo_and_bar :
     val ( <> ) : t -> t -> bool
     val equal : t -> t -> bool
     val compare : t -> t -> int
-...
-    module Replace_polymorphic_compare :
-      sig
-        val ( >= ) : t -> t -> bool
-        val ( <= ) : t -> t -> bool
-        val ( = ) : t -> t -> bool
-        val ( > ) : t -> t -> bool
-...
-      end
-    module Map :
-      sig
-...
-      end
-    module Set :
-      sig
-...
-      end
+    val min : t -> t -> t
+    val max : t -> t -> t
+    val ascending : t -> t -> int
+    val descending : t -> t -> int
+    val between : t -> low:t -> high:t -> bool
+    val clamp_exn : t -> min:t -> max:t -> t
+    val clamp : t -> min:t -> max:t -> t Base__.Or_error.t
+    type comparator_witness
+    val comparator : (t, comparator_witness) Comparator.t
+    val validate_lbound : min:t Core_kernel._maybe_bound -> t Validate.check
+    val validate_ubound : max:t Core_kernel._maybe_bound -> t Validate.check
+    val validate_bound :
+      min:t Core_kernel._maybe_bound ->
+      max:t Core_kernel._maybe_bound -> t Validate.check
   end
 |}];;
 
 [@@@part "23"];;
 module Foo_and_bar : sig
-  type t = { foo: Int.Set.t; bar: string }
+  type t = { foo: Set.M(Int).t; bar: string }
   include Comparable.S with type t := t
 end = struct
   module T = struct
-    type t = { foo: Int.Set.t; bar: string } [@@deriving sexp, compare]
+    type t = { foo: Set.M(Int).t; bar: string } [@@deriving sexp, compare]
   end
   include T
   include Comparable.Make(T)
@@ -271,12 +262,29 @@ end;;
 [%%expect ocaml {|
 module Foo_and_bar :
   sig
-    type t = { foo : Int.Set.t; bar : string; }
+    type t = { foo : Base.Set.M(Base.Int).t; bar : string; }
     val ( >= ) : t -> t -> bool
     val ( <= ) : t -> t -> bool
     val ( = ) : t -> t -> bool
     val ( > ) : t -> t -> bool
-...
+    val ( < ) : t -> t -> bool
+    val ( <> ) : t -> t -> bool
+    val equal : t -> t -> bool
+    val compare : t -> t -> int
+    val min : t -> t -> t
+    val max : t -> t -> t
+    val ascending : t -> t -> int
+    val descending : t -> t -> int
+    val between : t -> low:t -> high:t -> bool
+    val clamp_exn : t -> min:t -> max:t -> t
+    val clamp : t -> min:t -> max:t -> t Base__.Or_error.t
+    type comparator_witness
+    val comparator : (t, comparator_witness) Comparator.t
+    val validate_lbound : min:t Core_kernel._maybe_bound -> t Validate.check
+    val validate_ubound : max:t Core_kernel._maybe_bound -> t Validate.check
+    val validate_bound :
+      min:t Core_kernel._maybe_bound ->
+      max:t Core_kernel._maybe_bound -> t Validate.check
   end
 |}];;
 
@@ -327,21 +335,16 @@ Error: Unbound value table
 |}];;
 
 [@@@part "26"];;
-let table = String.Table.create ();;
-[%%expect ocaml {|val table : '_weak1 String.Table.t = <abstr>|}];;
+let table = Hashtbl.create (module String) ();;
+[%%expect ocaml {|val table : (string, '_weak1) Hashtbl.t = <abstr>|}];;
 
 [@@@part "27"];;
-let table = Hashtbl.create ~hashable:Hashtbl.Poly.hashable ();;
-[%%expect{|
-Characters 37-58:
-Error: The function applied to this argument has type
-         ?growth_allowed:bool -> ?size:int -> unit -> ('a, 'b) Hashtbl.t
-This argument cannot be applied with label ~hashable
-|}];;
+let table = Hashtbl.Poly.create ();;
+[%%expect ocaml {|val table : ('_weak2, '_weak3) Hashtbl.t = <abstr>|}];;
 
 [@@@part "28"];;
 let table = Hashtbl.Poly.create ();;
-[%%expect ocaml {|val table : ('_weak2, '_weak3) Hashtbl.t = <abstr>|}];;
+[%%expect ocaml {|val table : ('_weak4, '_weak5) Hashtbl.t = <abstr>|}];;
 
 [@@@part "29"];;
 Caml.Hashtbl.hash (List.range 0 9);;
@@ -364,285 +367,8 @@ end = struct
   include T
   include Hashable.Make(T)
 end;;
-[%%expect ocaml {|
-module Foo_and_bar :
-  sig
-    type t = { foo : int; bar : string; }
-    val compare : t -> t -> int
-    val hash_fold_t : Hash.state -> t -> Hash.state
-    val hash : t -> int
-    val hashable : t Hashtbl_intf.Hashable.t
-    module Table :
-      sig
-        type key = t
-        type ('a, 'b) hashtbl = ('a, 'b) Hashtbl.t
-        type 'b t = (key, 'b) hashtbl
-        val sexp_of_t : ('b -> Sexp.t) -> 'b t -> Sexp.t
-        type ('a, 'b) t_ = 'b t
-        type 'a key_ = key
-        val hashable : key Hashtbl_intf.Hashable.t
-        val invariant :
-          'a Base__Invariant_intf.t -> 'a t Base__Invariant_intf.t
-        val create :
-          (key, 'b, unit -> 'b t)
-          Hashtbl_intf.create_options_without_hashable
-        val of_alist :
-          (key, 'b,
-           (key * 'b) list -> [ `Duplicate_key of key | `Ok of 'b t ])
-          Hashtbl_intf.create_options_without_hashable
-        val of_alist_report_all_dups :
-          (key, 'b,
-           (key * 'b) list -> [ `Duplicate_keys of key list | `Ok of 'b t ])
-          Hashtbl_intf.create_options_without_hashable
-        val of_alist_or_error :
-          (key, 'b, (key * 'b) list -> 'b t Base__.Or_error.t)
-          Hashtbl_intf.create_options_without_hashable
-        val of_alist_exn :
-          (key, 'b, (key * 'b) list -> 'b t)
-          Hashtbl_intf.create_options_without_hashable
-        val of_alist_multi :
-          (key, 'b list, (key * 'b) list -> 'b list t)
-          Hashtbl_intf.create_options_without_hashable
-        val create_mapped :
-          (key, 'b,
-           get_key:('r -> key) ->
-           get_data:('r -> 'b) ->
-           'r list -> [ `Duplicate_keys of key list | `Ok of 'b t ])
-          Hashtbl_intf.create_options_without_hashable
-        val create_with_key :
-          (key, 'r,
-           get_key:('r -> key) ->
-           'r list -> [ `Duplicate_keys of key list | `Ok of 'r t ])
-          Hashtbl_intf.create_options_without_hashable
-        val create_with_key_or_error :
-          (key, 'r, get_key:('r -> key) -> 'r list -> 'r t Base__.Or_error.t)
-          Hashtbl_intf.create_options_without_hashable
-        val create_with_key_exn :
-          (key, 'r, get_key:('r -> key) -> 'r list -> 'r t)
-          Hashtbl_intf.create_options_without_hashable
-        val group :
-          (key, 'b,
-           get_key:('r -> key) ->
-           get_data:('r -> 'b) -> combine:('b -> 'b -> 'b) -> 'r list -> 'b t)
-          Hashtbl_intf.create_options_without_hashable
-        val sexp_of_key : 'a t -> key -> Sexp.t
-        val clear : 'a t -> unit
-        val copy : 'b t -> 'b t
-        val fold :
-          'b t -> init:'c -> f:(key:key -> data:'b -> 'c -> 'c) -> 'c
-        val iter_keys : 'a t -> f:(key -> unit) -> unit
-        val iter : 'b t -> f:('b -> unit) -> unit
-        val iteri : 'b t -> f:(key:key -> data:'b -> unit) -> unit
-        val existsi : 'b t -> f:(key:key -> data:'b -> bool) -> bool
-        val exists : 'b t -> f:('b -> bool) -> bool
-        val for_alli : 'b t -> f:(key:key -> data:'b -> bool) -> bool
-        val for_all : 'b t -> f:('b -> bool) -> bool
-        val counti : 'b t -> f:(key:key -> data:'b -> bool) -> int
-        val count : 'b t -> f:('b -> bool) -> int
-        val length : 'a t -> int
-        val is_empty : 'a t -> bool
-        val mem : 'a t -> key -> bool
-        val remove : 'a t -> key -> unit
-        val set : 'b t -> key:key -> data:'b -> unit
-        val add : 'b t -> key:key -> data:'b -> [ `Duplicate | `Ok ]
-        val add_exn : 'b t -> key:key -> data:'b -> unit
-        val change : 'b t -> key -> f:('b option -> 'b option) -> unit
-        val update : 'b t -> key -> f:('b option -> 'b) -> unit
-        val map : 'b t -> f:('b -> 'c) -> 'c t
-        val mapi : 'b t -> f:(key:key -> data:'b -> 'c) -> 'c t
-        val filter_map : 'b t -> f:('b -> 'c option) -> 'c t
-        val filter_mapi : 'b t -> f:(key:key -> data:'b -> 'c option) -> 'c t
-        val filter_keys : 'b t -> f:(key -> bool) -> 'b t
-        val filter : 'b t -> f:('b -> bool) -> 'b t
-        val filteri : 'b t -> f:(key:key -> data:'b -> bool) -> 'b t
-        val partition_map :
-          'b t -> f:('b -> [ `Fst of 'c | `Snd of 'd ]) -> 'c t * 'd t
-        val partition_mapi :
-          'b t ->
-          f:(key:key -> data:'b -> [ `Fst of 'c | `Snd of 'd ]) ->
-          'c t * 'd t
-        val partition_tf : 'b t -> f:('b -> bool) -> 'b t * 'b t
-        val partitioni_tf :
-          'b t -> f:(key:key -> data:'b -> bool) -> 'b t * 'b t
-        val find_or_add : 'b t -> key -> default:(unit -> 'b) -> 'b
-        val find : 'b t -> key -> 'b option
-        val find_exn : 'b t -> key -> 'b
-        val find_and_call :
-          'b t ->
-          key -> if_found:('b -> 'c) -> if_not_found:(key -> 'c) -> 'c
-        val find_and_remove : 'b t -> key -> 'b option
-        val merge :
-          'a t ->
-          'b t ->
-          f:(key:key ->
-             [ `Both of 'a * 'b | `Left of 'a | `Right of 'b ] -> 'c option) ->
-          'c t
-        type 'a merge_into_action = Remove | Set_to of 'a
-        val merge_into :
-          src:'a t ->
-          dst:'b t ->
-          f:(key:key -> 'a -> 'b option -> 'b merge_into_action) -> unit
-        val keys : 'a t -> key list
-        val data : 'b t -> 'b list
-        val filter_keys_inplace : 'a t -> f:(key -> bool) -> unit
-        val filter_inplace : 'b t -> f:('b -> bool) -> unit
-        val filteri_inplace : 'b t -> f:(key:key -> data:'b -> bool) -> unit
-        val map_inplace : 'b t -> f:('b -> 'b) -> unit
-        val mapi_inplace : 'b t -> f:(key:key -> data:'b -> 'b) -> unit
-        val filter_map_inplace : 'b t -> f:('b -> 'b option) -> unit
-        val filter_mapi_inplace :
-          'b t -> f:(key:key -> data:'b -> 'b option) -> unit
-        val equal : 'b t -> 'b t -> ('b -> 'b -> bool) -> bool
-        val similar : 'b1 t -> 'b2 t -> ('b1 -> 'b2 -> bool) -> bool
-        val to_alist : 'b t -> (key * 'b) list
-        val validate :
-          name:(key -> string) -> 'b Validate.check -> 'b t Validate.check
-        val incr : ?by:int -> ?remove_if_zero:bool -> int t -> key -> unit
-        val decr : ?by:int -> ?remove_if_zero:bool -> int t -> key -> unit
-        val add_multi : 'b list t -> key:key -> data:'b -> unit
-        val remove_multi : 'a list t -> key -> unit
-        val find_multi : 'b list t -> key -> 'b list
-        module Provide_of_sexp :
-          functor (Key : sig val t_of_sexp : Sexp.t -> key end) ->
-            sig
-              val t_of_sexp :
-                (Sexp.t -> 'v_x__001_) -> Sexp.t -> 'v_x__001_ t
-            end
-        module Provide_bin_io :
-          functor
-            (Key : sig
-                     val bin_t : key Bin_prot.Type_class.t0
-                     val bin_read_t : key Bin_prot.Read.reader
-                     val __bin_read_t__ : (int -> key) Bin_prot.Read.reader
-                     val bin_reader_t : key Bin_prot.Type_class.reader0
-                     val bin_size_t : key Bin_prot.Size.sizer
-                     val bin_write_t : key Bin_prot.Write.writer
-                     val bin_writer_t : key Bin_prot.Type_class.writer0
-                     val bin_shape_t : Bin_prot.Shape.t
-                   end) ->
-            sig
-              val bin_t :
-                'a Bin_prot.Type_class.t0 -> 'a t Bin_prot.Type_class.t0
-              val bin_read_t :
-                'a Bin_prot.Read.reader -> 'a t Bin_prot.Read.reader
-              val __bin_read_t__ :
-                'a Bin_prot.Read.reader -> (int -> 'a t) Bin_prot.Read.reader
-              val bin_reader_t :
-                'a Bin_prot.Type_class.reader0 ->
-                'a t Bin_prot.Type_class.reader0
-              val bin_size_t :
-                'a Bin_prot.Size.sizer -> 'a t Bin_prot.Size.sizer
-              val bin_write_t :
-                'a Bin_prot.Write.writer -> 'a t Bin_prot.Write.writer
-              val bin_writer_t :
-                'a Bin_prot.Type_class.writer0 ->
-                'a t Bin_prot.Type_class.writer0
-              val bin_shape_t : Bin_prot.Shape.t -> Bin_prot.Shape.t
-            end
-        val t_of_sexp : (Sexp.t -> 'v_x__002_) -> Sexp.t -> 'v_x__002_ t
-      end
-    module Hash_set :
-      sig
-        type elt = t
-        type t = elt Hash_set.t
-        val sexp_of_t : t -> Sexp.t
-        type 'a t_ = t
-        type 'a elt_ = elt
-        val create :
-          ('a, unit -> t)
-          Core_kernel__.Hash_set_intf.create_options_without_hashable
-        val of_list :
-          ('a, elt list -> t)
-          Core_kernel__.Hash_set_intf.create_options_without_hashable
-        module Provide_of_sexp :
-          functor (X : sig val t_of_sexp : Sexp.t -> elt end) ->
-            sig val t_of_sexp : Sexp.t -> t end
-        module Provide_bin_io :
-          functor
-            (X : sig
-                   val bin_t : elt Bin_prot.Type_class.t0
-                   val bin_read_t : elt Bin_prot.Read.reader
-                   val __bin_read_t__ : (int -> elt) Bin_prot.Read.reader
-                   val bin_reader_t : elt Bin_prot.Type_class.reader0
-                   val bin_size_t : elt Bin_prot.Size.sizer
-                   val bin_write_t : elt Bin_prot.Write.writer
-                   val bin_writer_t : elt Bin_prot.Type_class.writer0
-                   val bin_shape_t : Bin_prot.Shape.t
-                 end) ->
-            sig
-              val bin_t : t Bin_prot.Type_class.t0
-              val bin_read_t : t Bin_prot.Read.reader
-              val __bin_read_t__ : (int -> t) Bin_prot.Read.reader
-              val bin_reader_t : t Bin_prot.Type_class.reader0
-              val bin_size_t : t Bin_prot.Size.sizer
-              val bin_write_t : t Bin_prot.Write.writer
-              val bin_writer_t : t Bin_prot.Type_class.writer0
-              val bin_shape_t : Bin_prot.Shape.t
-            end
-        val t_of_sexp : Sexp.t -> t
-      end
-    module Hash_queue :
-      sig
-        module Key :
-          sig
-            type t = Hash_set.elt
-            val compare : t -> t -> int
-            val sexp_of_t : t -> Sexp.t
-            val hash : t -> int
-          end
-        type 'a t
-        val sexp_of_t : ('a -> Sexp.t) -> 'a t -> Sexp.t
-        val length : 'a t -> int
-        val is_empty : 'a t -> bool
-        val iter : 'a t -> f:('a -> unit) -> unit
-        val fold :
-          'a t -> init:'accum -> f:('accum -> 'a -> 'accum) -> 'accum
-        val fold_result :
-          'a t ->
-          init:'accum ->
-          f:('accum -> 'a -> ('accum, 'e) result) -> ('accum, 'e) result
-        val fold_until :
-          'a t ->
-          init:'accum ->
-          f:('accum -> 'a -> ('accum, 'stop) Base.Continue_or_stop.t) ->
-          ('accum, 'stop) Base.Finished_or_stopped_early.t
-        val exists : 'a t -> f:('a -> bool) -> bool
-        val for_all : 'a t -> f:('a -> bool) -> bool
-        val count : 'a t -> f:('a -> bool) -> int
-        val sum :
-          (module Base__.Commutative_group.S with type t = 'sum) ->
-          'a t -> f:('a -> 'sum) -> 'sum
-        val find : 'a t -> f:('a -> bool) -> 'a option
-        val find_map : 'a t -> f:('a -> 'b option) -> 'b option
-        val to_list : 'a t -> 'a list
-        val to_array : 'a t -> 'a array
-        val min_elt : 'a t -> cmp:('a -> 'a -> int) -> 'a option
-        val max_elt : 'a t -> cmp:('a -> 'a -> int) -> 'a option
-        val invariant : 'a t -> unit
-        val create : ?growth_allowed:bool -> ?size:int -> unit -> 'a t
-        val clear : 'a t -> unit
-        val mem : 'a t -> Key.t -> bool
-        val lookup : 'a t -> Key.t -> 'a option
-        val lookup_exn : 'a t -> Key.t -> 'a
-        val enqueue : 'a t -> Key.t -> 'a -> [ `Key_already_present | `Ok ]
-        val enqueue_exn : 'a t -> Key.t -> 'a -> unit
-        val lookup_and_move_to_back : 'a t -> Key.t -> 'a option
-        val lookup_and_move_to_back_exn : 'a t -> Key.t -> 'a
-        val first : 'a t -> 'a option
-        val first_with_key : 'a t -> (Key.t * 'a) option
-        val keys : 'a t -> Key.t list
-        val dequeue : 'a t -> 'a option
-        val dequeue_exn : 'a t -> 'a
-        val dequeue_with_key : 'a t -> (Key.t * 'a) option
-        val dequeue_with_key_exn : 'a t -> Key.t * 'a
-        val dequeue_all : 'a t -> f:('a -> unit) -> unit
-        val remove : 'a t -> Key.t -> [ `No_such_key | `Ok ]
-        val remove_exn : 'a t -> Key.t -> unit
-        val replace : 'a t -> Key.t -> 'a -> [ `No_such_key | `Ok ]
-        val replace_exn : 'a t -> Key.t -> 'a -> unit
-        val iteri : 'a t -> f:(key:Key.t -> data:'a -> unit) -> unit
-        val foldi :
-          'a t -> init:'b -> f:('b -> key:Key.t -> data:'a -> 'b) -> 'b
-      end
-  end
+[%%expect{|
+Characters 233-246:
+Error: Unbound module Hashable
+Hint: Did you mean Hashtbl or Hashtbl?
 |}];;

--- a/examples/code/maps-and-hash-tables/main.mlt
+++ b/examples/code/maps-and-hash-tables/main.mlt
@@ -42,7 +42,9 @@ Map.of_alist_exn;;
 - : ('a, 'cmp) Map.comparator -> ('a * 'b) list -> ('a, 'b, 'cmp) Map.t =
 <fun>
 |}];;
-[@@@part "5"];;
+
+
+[@@@part "mc.3"];;
 let left = Map.of_alist_exn (module String) ["foo",1; "bar",3; "snoo",0];;
 [%%expect ocaml {|val left : (string, int, String.comparator_witness) Map.t = <abstr>|}];;
 let right = Map.of_alist_exn (module String) ["foo",0; "snoo",0];;
@@ -53,7 +55,7 @@ Map.symmetric_diff ~data_equal:Int.equal left right |> Sequence.to_list;;
 [("bar", `Left 3); ("foo", `Unequal (1, 0))]
 |}];;
 
-[@@@part "6"];;
+[@@@part "mc.4"];;
 Map.symmetric_diff;;
 [%%expect ocaml {|
 - : ('k, 'v, 'cmp) Map.t ->
@@ -63,7 +65,7 @@ Map.symmetric_diff;;
 = <fun>
 |}];;
 
-[@@@part "7"];;
+[@@@part "mc.5"];;
 module Reverse = struct
   module T = struct
     type t = string
@@ -93,7 +95,7 @@ module Reverse :
   end
 |}];;
 
-[@@@part "8"];;
+[@@@part "mc.6"];;
 let alist = ["foo", 0; "snoo", 3];;
 [%%expect ocaml {|val alist : (string * int) list = [("foo", 0); ("snoo", 3)]|}];;
 let ord_map = Map.of_alist_exn (module String) alist;;
@@ -101,13 +103,13 @@ let ord_map = Map.of_alist_exn (module String) alist;;
 let rev_map = Map.of_alist_exn (module Reverse) alist;;
 [%%expect ocaml {|val rev_map : (string, int, Reverse.comparator_witness) Map.t = <abstr>|}];;
 
-[@@@part "9"];;
+[@@@part "mc.7"];;
 Map.min_elt ord_map;;
 [%%expect ocaml {|- : (string * int) option = Some ("foo", 0)|}];;
 Map.min_elt rev_map;;
 [%%expect ocaml {|- : (string * int) option = Some ("snoo", 3)|}];;
 
-[@@@part "10"];;
+[@@@part "mc.8"];;
 Map.symmetric_diff ord_map rev_map;;
 [%%expect{|
 Characters 27-34:

--- a/examples/code/maps-and-hash-tables/map_vs_hash/jbuild
+++ b/examples/code/maps-and-hash-tables/map_vs_hash/jbuild
@@ -3,5 +3,5 @@
 
 (executable
   ((name map_vs_hash)
-   (libraries (core_bench))
+   (libraries (base core_bench))
   ))

--- a/examples/code/maps-and-hash-tables/map_vs_hash/map_vs_hash.ml
+++ b/examples/code/maps-and-hash-tables/map_vs_hash/map_vs_hash.ml
@@ -1,21 +1,21 @@
-open Core_kernel
+open Base
 open Core_bench
 
 let map_iter ~num_keys ~iterations =
   let rec loop i map =
     if i <= 0 then ()
     else loop (i - 1)
-           (Map.change map (i mod num_keys) ~f:(fun current ->
+           (Map.change map (i % num_keys) ~f:(fun current ->
               Some (1 + Option.value ~default:0 current)))
   in
-  loop iterations Int.Map.empty
+  loop iterations (Map.empty (module Int))
 
 let table_iter ~num_keys ~iterations =
-  let table = Int.Table.create ~size:num_keys () in
+  let table = Hashtbl.create (module Int) ~size:num_keys () in
   let rec loop i =
     if i <= 0 then ()
     else (
-      Hashtbl.change table (i mod num_keys) ~f:(fun current ->
+      Hashtbl.change table (i % num_keys) ~f:(fun current ->
         Some (1 + Option.value ~default:0 current));
       loop (i - 1)
     )

--- a/examples/code/maps-and-hash-tables/map_vs_hash2/map_vs_hash2.ml
+++ b/examples/code/maps-and-hash-tables/map_vs_hash2/map_vs_hash2.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Base
 open Core_bench
 
 let create_maps ~num_keys ~iterations =
@@ -6,19 +6,19 @@ let create_maps ~num_keys ~iterations =
     if i <= 0 then []
     else
       let new_map =
-        Map.change map (i mod num_keys) ~f:(fun current ->
+        Map.change map (i % num_keys) ~f:(fun current ->
           Some (1 + Option.value ~default:0 current))
       in
       new_map :: loop (i - 1) new_map
   in
-  loop iterations Int.Map.empty
+  loop iterations (Map.empty (module Int))
 
 let create_tables ~num_keys ~iterations =
-  let table = Int.Table.create ~size:num_keys () in
+  let table = Hashtbl.create (module Int) ~size:num_keys () in
   let rec loop i =
     if i <= 0 then []
     else (
-      Hashtbl.change table (i mod num_keys) ~f:(fun current ->
+      Hashtbl.change table (i % num_keys) ~f:(fun current ->
         Some (1 + Option.value ~default:0 current));
       let new_table = Hashtbl.copy table in
       new_table :: loop (i - 1)


### PR DESCRIPTION
This is a pretty big rewrite, and reading the diff on github isn't easy, especially because the text and the mlt code aren't together in one file. If you want to read it over, probably the easiest way is to generate the HTML and read it.

There's more I should maybe add in a followup patch, including a section describing how to use Map.M(Int).t and why it's useful.

Also, there's an unrelated fix to an example in the first-class-module section where a section was marked as non-deterministic. This was getting in the way of the build.