### PR TITLE
Remove jbuild.deps files

### DIFF
--- a/examples/code/async/jbuild.inc
+++ b/examples/code/async/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (main.mlt))
+  (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/classes/jbuild.inc
+++ b/examples/code/classes/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (iter.mlt))
+  (deps (iter.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (istack.mlt))
+  (deps (istack.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -18,7 +18,7 @@
 
 (alias (
   (name code)
-  (deps (stack.mlt))
+  (deps (stack.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -26,7 +26,7 @@
 
 (alias (
   (name code)
-  (deps (binary.mlt))
+  (deps (binary.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -34,7 +34,7 @@
 
 (alias (
   (name code)
-  (deps (initializer.mlt))
+  (deps (initializer.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/command-line-parsing/jbuild.inc
+++ b/examples/code/command-line-parsing/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (group.mlt))
+  (deps (group.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (step.mlt))
+  (deps (step.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -18,7 +18,7 @@
 
 (alias (
   (name code)
-  (deps (command_types.mlt))
+  (deps (command_types.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -26,7 +26,7 @@
 
 (alias (
   (name code)
-  (deps (basic.mlt))
+  (deps (basic.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/error-handling/jbuild.inc
+++ b/examples/code/error-handling/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (main.mlt))
+  (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/fcm/jbuild.inc
+++ b/examples/code/fcm/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (query_handler.mlt))
+  (deps (query_handler.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (main.mlt))
+  (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/ffi/jbuild.inc
+++ b/examples/code/ffi/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (posix.mlt))
+  (deps (posix.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (qsort.mlt))
+  (deps (qsort.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/files-modules-and-programs/jbuild.inc
+++ b/examples/code/files-modules-and-programs/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (main.mlt))
+  (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (intro.mlt))
+  (deps (intro.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/front-end/jbuild.inc
+++ b/examples/code/front-end/jbuild.inc
@@ -66,7 +66,7 @@
 
 (alias (
   (name code)
-  (deps (camlp4_toplevel.mlt))
+  (deps (camlp4_toplevel.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/functors/jbuild.inc
+++ b/examples/code/functors/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (main.mlt))
+  (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/gadts/jbuild.inc
+++ b/examples/code/gadts/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (main.mlt))
+  (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/gc/jbuild.inc
+++ b/examples/code/gc/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (tune.mlt))
+  (deps (tune.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/guided-tour/jbuild.inc
+++ b/examples/code/guided-tour/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (main.mlt))
+  (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (local_let.mlt))
+  (deps (local_let.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/imperative-programming/jbuild.inc
+++ b/examples/code/imperative-programming/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (for.mlt))
+  (deps (for.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (order.mlt))
+  (deps (order.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -18,7 +18,7 @@
 
 (alias (
   (name code)
-  (deps (file.mlt))
+  (deps (file.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -26,7 +26,7 @@
 
 (alias (
   (name code)
-  (deps (file2.mlt))
+  (deps (file2.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -34,7 +34,7 @@
 
 (alias (
   (name code)
-  (deps (letrec.mlt))
+  (deps (letrec.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -42,7 +42,7 @@
 
 (alias (
   (name code)
-  (deps (fib.mlt))
+  (deps (fib.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -50,7 +50,7 @@
 
 (alias (
   (name code)
-  (deps (examples.mlt))
+  (deps (examples.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -58,7 +58,7 @@
 
 (alias (
   (name code)
-  (deps (weak.mlt))
+  (deps (weak.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -66,7 +66,7 @@
 
 (alias (
   (name code)
-  (deps (memo.mlt))
+  (deps (memo.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -74,7 +74,7 @@
 
 (alias (
   (name code)
-  (deps (printf.mlt))
+  (deps (printf.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -82,7 +82,7 @@
 
 (alias (
   (name code)
-  (deps (value_restriction.mlt))
+  (deps (value_restriction.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -90,7 +90,7 @@
 
 (alias (
   (name code)
-  (deps (ref.mlt))
+  (deps (ref.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -98,7 +98,7 @@
 
 (alias (
   (name code)
-  (deps (lazy.mlt))
+  (deps (lazy.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/json/jbuild.deps
+++ b/examples/code/json/jbuild.deps
@@ -1,1 +1,0 @@
-((parse_book.mlt (book.json)))

--- a/examples/code/json/jbuild.inc
+++ b/examples/code/json/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (build_json.mlt))
+  (deps (build_json.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (install.mlt))
+  (deps (install.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -26,7 +26,7 @@
 
 (alias (
   (name code)
-  (deps (parse_book.mlt book.json))
+  (deps (parse_book.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/lists-and-patterns/jbuild.inc
+++ b/examples/code/lists-and-patterns/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (main.mlt))
+  (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (poly.mlt))
+  (deps (poly.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/maps-and-hash-tables/jbuild.inc
+++ b/examples/code/maps-and-hash-tables/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (main.mlt))
+  (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (core_phys_equal.mlt))
+  (deps (core_phys_equal.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/memory-repr/jbuild.inc
+++ b/examples/code/memory-repr/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (reprs.mlt))
+  (deps (reprs.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (simple_record.mlt))
+  (deps (simple_record.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/objects/jbuild.inc
+++ b/examples/code/objects/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (polymorphism.mlt))
+  (deps (polymorphism.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (row_polymorphism.mlt))
+  (deps (row_polymorphism.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -18,7 +18,7 @@
 
 (alias (
   (name code)
-  (deps (stack.mlt))
+  (deps (stack.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -26,7 +26,7 @@
 
 (alias (
   (name code)
-  (deps (immutable.mlt))
+  (deps (immutable.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -34,7 +34,7 @@
 
 (alias (
   (name code)
-  (deps (subtyping.mlt))
+  (deps (subtyping.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/records/jbuild.inc
+++ b/examples/code/records/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (main.mlt))
+  (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (main2.mlt))
+  (deps (main2.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/sexpr/jbuild.deps
+++ b/examples/code/sexpr/jbuild.deps
@@ -1,1 +1,0 @@
-((example_load.mlt (example.scm example_broken.scm comment_heavy.scm)))

--- a/examples/code/sexpr/jbuild.inc
+++ b/examples/code/sexpr/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (sexp_option.mlt))
+  (deps (sexp_option.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (manually_making_sexp.mlt))
+  (deps (manually_making_sexp.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -18,7 +18,7 @@
 
 (alias (
   (name code)
-  (deps (inline_sexp.mlt))
+  (deps (inline_sexp.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -26,7 +26,7 @@
 
 (alias (
   (name code)
-  (deps (sexp_default.mlt))
+  (deps (sexp_default.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -34,7 +34,7 @@
 
 (alias (
   (name code)
-  (deps (sexp_printer.mlt))
+  (deps (sexp_printer.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -42,7 +42,7 @@
 
 (alias (
   (name code)
-  (deps (auto_making_sexp.mlt))
+  (deps (auto_making_sexp.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -50,7 +50,7 @@
 
 (alias (
   (name code)
-  (deps (example_load.mlt example.scm example_broken.scm comment_heavy.scm))
+  (deps (example_load.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -58,7 +58,7 @@
 
 (alias (
   (name code)
-  (deps (to_from_sexp.mlt))
+  (deps (to_from_sexp.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -74,7 +74,7 @@
 
 (alias (
   (name code)
-  (deps (print_sexp.mlt))
+  (deps (print_sexp.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -82,7 +82,7 @@
 
 (alias (
   (name code)
-  (deps (sexp_list.mlt))
+  (deps (sexp_list.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -90,7 +90,7 @@
 
 (alias (
   (name code)
-  (deps (sexp_opaque.mlt))
+  (deps (sexp_opaque.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/variables-and-functions/jbuild.inc
+++ b/examples/code/variables-and-functions/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (main.mlt))
+  (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))

--- a/examples/code/variants/jbuild.inc
+++ b/examples/code/variants/jbuild.inc
@@ -2,7 +2,7 @@
 
 (alias (
   (name code)
-  (deps (logger.mlt))
+  (deps (logger.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -10,7 +10,7 @@
 
 (alias (
   (name code)
-  (deps (main.mlt))
+  (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -18,7 +18,7 @@
 
 (alias (
   (name code)
-  (deps (catch_all.mlt))
+  (deps (catch_all.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
@@ -26,7 +26,7 @@
 
 (alias (
   (name code)
-  (deps (blang.mlt))
+  (deps (blang.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))


### PR DESCRIPTION
.mlt files now implicitely depends on all files in the same directory and
its subdirectories.