### PR TITLE
Split the build into 3 steps: run deterministic tests, run non-deterministic tests, generate HTML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-.PHONY: all clean dep code publish promote cram
+.PHONY: all clean dep publish promote test test-all
 
 all:
 	@jbuilder build @site --dev
 	@echo Site has been generated in _build/default/static/
 
-code:
-	jbuilder build @code --dev
+test:
+	jbuilder runtest --dev
 
-cram:
-	jbuilder build @cram --dev
+test-all:
+	jbuilder build @runtest-all --dev
 
 dep:
 	jbuilder exec --dev -- rwo-jbuild

--- a/bin/bin/gen_jbuild.ml
+++ b/bin/bin/gen_jbuild.ml
@@ -120,25 +120,36 @@ let process_chapters book_dir output_dir =
 (** Handle examples *)
 
 let mlt_rule f =
-  sprintf {|
+  let alias name cmd =
+    sprintf {|
 (alias
- ((name    code)
+ ((name    %s)
   (deps    (%s (files_recursively_in .)))
   (action  (progn
-    (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (setenv OCAMLRUNPARAM "" (run %s ${<}))
     (diff? ${<} ${<}.corrected)))))|}
-    f
+      name f cmd
+  in
+  sprintf "%s\n\n%s\n"
+    (alias "runtest"     "ocaml-topexpect -short-paths -verbose")
+    (alias "runtest-all" "ocaml-topexpect -non-deterministic -short-paths -verbose")
 
 let sh_rule f =
-  sprintf {|
+  let alias name cmd =
+    sprintf {|
 (alias
- ((name     cram)
+ ((name     %s)
   (deps     (%s (files_recursively_in .)))
   (action
     (progn
-     (run cram ${<})
+     (run %s ${<})
      (diff? ${<} ${<}.corrected)))))|}
-    f
+      name f cmd
+  in
+  sprintf "%s\n\n%s\n"
+    (alias "runtest"     "cram")
+    (alias "runtest-all" "cram --non-deterministic")
+
 
 let process_examples dir =
   Filename.concat dir "jbuild.inc" |> fun jbuild ->

--- a/examples/code/async/echo/jbuild.inc
+++ b/examples/code/async/echo/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_echo.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_echo.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/async/jbuild.inc
+++ b/examples/code/async/jbuild.inc
@@ -1,10 +1,19 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (main.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/async/search/jbuild.inc
+++ b/examples/code/async/search/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_search.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_search.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/async/search_with_configurable_server/jbuild.inc
+++ b/examples/code/async/search_with_configurable_server/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_search_with_configurable_server.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_search_with_configurable_server.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/async/search_with_error_handling/jbuild.inc
+++ b/examples/code/async/search_with_error_handling/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_search_with_error_handling.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_search_with_error_handling.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/async/search_with_timeout_no_leak/jbuild.inc
+++ b/examples/code/async/search_with_timeout_no_leak/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_search_with_timeout_no_leak.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_search_with_timeout_no_leak.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/async/search_with_timeout_no_leak_simple/jbuild.inc
+++ b/examples/code/async/search_with_timeout_no_leak_simple/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_search_with_timeout_no_leak_simple.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_search_with_timeout_no_leak_simple.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/back-end-embed/jbuild.inc
+++ b/examples/code/back-end-embed/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_embed.sh (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,22 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (build_embed.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (run_debug_hello.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_debug_hello.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/back-end/alternate_list/jbuild.inc
+++ b/examples/code/back-end/alternate_list/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_alternate_list.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_alternate_list.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/back-end/bench_patterns/jbuild.inc
+++ b/examples/code/back-end/bench_patterns/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_bench_patterns.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_bench_patterns.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/back-end/bench_poly_and_mono/jbuild.inc
+++ b/examples/code/back-end/bench_poly_and_mono/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_bench_poly_and_mono.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_bench_poly_and_mono.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/back-end/jbuild.inc
+++ b/examples/code/back-end/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (instr_for_pattern_monomorphic_small.sh (files_recursively_in .)))
   (action (
     progn
@@ -9,7 +9,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (instr_for_pattern_monomorphic_small.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (asm_from_compare_mono.sh (files_recursively_in .)))
   (action (
     progn
@@ -17,7 +23,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (asm_from_compare_mono.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (lambda_for_pattern_monomorphic_large.sh (files_recursively_in .)))
   (action (
     progn
@@ -25,7 +37,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (lambda_for_pattern_monomorphic_large.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (lambda_for_pattern_monomorphic_small.sh (files_recursively_in .)))
   (action (
     progn
@@ -33,10 +51,22 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (lambda_for_pattern_monomorphic_small.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (lambda_for_pattern_polymorphic.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (lambda_for_pattern_polymorphic.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/classes-async/shapes/jbuild.inc
+++ b/examples/code/classes-async/shapes/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_shapes.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_shapes.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/classes/jbuild.inc
+++ b/examples/code/classes/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (iter.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,7 +9,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (iter.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (istack.mlt (files_recursively_in .)))
   (action (
     progn
@@ -17,7 +26,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (istack.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (stack.mlt (files_recursively_in .)))
   (action (
     progn
@@ -25,7 +43,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (stack.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (binary.mlt (files_recursively_in .)))
   (action (
     progn
@@ -33,10 +60,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (binary.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (initializer.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (initializer.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/command-line-parsing/basic_md5/jbuild.inc
+++ b/examples/code/command-line-parsing/basic_md5/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (basic_md5.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (basic_md5.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/command-line-parsing/basic_md5_as_filename/jbuild.inc
+++ b/examples/code/command-line-parsing/basic_md5_as_filename/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_basic_md5_as_filename.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_basic_md5_as_filename.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/command-line-parsing/basic_md5_with_custom_arg/jbuild.inc
+++ b/examples/code/command-line-parsing/basic_md5_with_custom_arg/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_basic_md5_with_custom_arg.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_basic_md5_with_custom_arg.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/command-line-parsing/basic_md5_with_flags/jbuild.inc
+++ b/examples/code/command-line-parsing/basic_md5_with_flags/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (basic_md5_with_flags.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (basic_md5_with_flags.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/command-line-parsing/basic_md5_with_optional_file/jbuild.inc
+++ b/examples/code/command-line-parsing/basic_md5_with_optional_file/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (basic_and_default_md5.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (basic_and_default_md5.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/command-line-parsing/basic_md5_with_optional_file_broken/jbuild.inc
+++ b/examples/code/command-line-parsing/basic_md5_with_optional_file_broken/jbuild.inc
@@ -1,11 +1,18 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (
     build_basic_md5_with_optional_file_broken.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (
+    build_basic_md5_with_optional_file_broken.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/command-line-parsing/cal_add_interactive/jbuild.inc
+++ b/examples/code/command-line-parsing/cal_add_interactive/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_and_run_cal_add_interactive.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_and_run_cal_add_interactive.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/command-line-parsing/cal_add_sub_days/jbuild.inc
+++ b/examples/code/command-line-parsing/cal_add_sub_days/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (cal_add_sub_days.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (cal_add_sub_days.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/command-line-parsing/cal_append_broken/jbuild.inc
+++ b/examples/code/command-line-parsing/cal_append_broken/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_cal_append_broken.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_cal_append_broken.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/command-line-parsing/jbuild.inc
+++ b/examples/code/command-line-parsing/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (group.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,7 +9,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (group.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (step.mlt (files_recursively_in .)))
   (action (
     progn
@@ -17,7 +26,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (step.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (command_types.mlt (files_recursively_in .)))
   (action (
     progn
@@ -25,10 +43,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (command_types.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (basic.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (basic.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/error-handling/blow_up/jbuild.inc
+++ b/examples/code/error-handling/blow_up/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_blow_up.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_blow_up.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/error-handling/exn_cost/jbuild.inc
+++ b/examples/code/error-handling/exn_cost/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_exn_cost.sh (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,22 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (run_exn_cost.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (run_exn_cost_notrace.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_exn_cost_notrace.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/error-handling/jbuild.inc
+++ b/examples/code/error-handling/jbuild.inc
@@ -1,10 +1,19 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (main.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/fcm/jbuild.inc
+++ b/examples/code/fcm/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (query_handler.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (query_handler.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (main.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/fcm/query_handler_loader/jbuild.inc
+++ b/examples/code/fcm/query_handler_loader/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_query_handler_loader.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_query_handler_loader.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/ffi/datetime/jbuild.inc
+++ b/examples/code/ffi/datetime/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_datetime.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_datetime.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/ffi/hello/jbuild.inc
+++ b/examples/code/ffi/hello/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_hello.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_hello.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/ffi/jbuild.inc
+++ b/examples/code/ffi/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (posix.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (posix.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (qsort.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (qsort.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/ffi/ncurses/jbuild.inc
+++ b/examples/code/ffi/ncurses/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (infer_ncurses.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (infer_ncurses.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/ffi/qsort/jbuild.inc
+++ b/examples/code/ffi/qsort/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_qsort.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_qsort.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq-cyclic1/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq-cyclic1/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq-cyclic2/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq-cyclic2/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq-fast/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq-fast/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq-median/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq-median/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq-obuild/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq-obuild/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (freq.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (freq.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq-with-counter/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq-with-counter/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build.sh (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,22 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (build.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (infer_mli.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (infer_mli.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq-with-missing-def/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq-with-missing-def/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq-with-sig-abstract-fixed/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq-with-sig-abstract-fixed/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq-with-sig-abstract/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq-with-sig-abstract/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq-with-sig-mismatch/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq-with-sig-mismatch/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq-with-sig/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq-with-sig/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq-with-type-mismatch/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq-with-type-mismatch/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/freq/jbuild.inc
+++ b/examples/code/files-modules-and-programs/freq/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (simple_build.sh (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,22 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (simple_build.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (simple_build_fail.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (simple_build_fail.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/jbuild.inc
+++ b/examples/code/files-modules-and-programs/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (main.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (intro.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (intro.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/files-modules-and-programs/session_info/jbuild.inc
+++ b/examples/code/files-modules-and-programs/session_info/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_session_info.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_session_info.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/front-end/jbuild.inc
+++ b/examples/code/front-end/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (infer_typedef.sh (files_recursively_in .)))
   (action (
     progn
@@ -9,7 +9,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (infer_typedef.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (build_principal_corebuild.sh (files_recursively_in .)))
   (action (
     progn
@@ -17,7 +23,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (build_principal_corebuild.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (build_broken_poly_with_annot.errsh (files_recursively_in .)))
   (action (
     progn
@@ -25,7 +37,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (build_broken_poly_with_annot.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (indent_follow_on_function.sh (files_recursively_in .)))
   (action (
     progn
@@ -33,7 +51,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (indent_follow_on_function.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (typedtree_typedef.sh (files_recursively_in .)))
   (action (
     progn
@@ -41,7 +65,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (typedtree_typedef.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (process_comparelib_interface.sh (files_recursively_in .)))
   (action (
     progn
@@ -49,7 +79,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (process_comparelib_interface.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (build_type_conv_without_camlp4.errsh (files_recursively_in .)))
   (action (
     progn
@@ -57,7 +93,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (build_type_conv_without_camlp4.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (build_principal.sh (files_recursively_in .)))
   (action (
     progn
@@ -65,7 +107,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (build_principal.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (camlp4_toplevel.mlt (files_recursively_in .)))
   (action (
     progn
@@ -73,7 +121,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (camlp4_toplevel.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (conflicting_interfaces.errsh (files_recursively_in .)))
   (action (
     progn
@@ -81,7 +138,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (conflicting_interfaces.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (build_broken_module.errsh (files_recursively_in .)))
   (action (
     progn
@@ -89,7 +152,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (build_broken_module.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (indent_follow_on_function_fixed.sh (files_recursively_in .)))
   (action (
     progn
@@ -97,7 +166,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (indent_follow_on_function_fixed.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (parsetree_typedef.sh (files_recursively_in .)))
   (action (
     progn
@@ -105,7 +180,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (parsetree_typedef.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (typedef_objinfo.sh (files_recursively_in .)))
   (action (
     progn
@@ -113,7 +194,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (typedef_objinfo.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (build_non_principal.sh (files_recursively_in .)))
   (action (
     progn
@@ -121,7 +208,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (build_non_principal.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (build_follow_on_function.errsh (files_recursively_in .)))
   (action (
     progn
@@ -129,7 +222,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (build_follow_on_function.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (build_broken_poly.errsh (files_recursively_in .)))
   (action (
     progn
@@ -137,10 +236,22 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (build_broken_poly.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (process_comparelib_test.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (process_comparelib_test.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/functors/jbuild.inc
+++ b/examples/code/functors/jbuild.inc
@@ -1,10 +1,19 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (main.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/gadts/jbuild.inc
+++ b/examples/code/gadts/jbuild.inc
@@ -1,10 +1,19 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (main.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/gc/barrier_bench/jbuild.inc
+++ b/examples/code/gc/barrier_bench/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (barrier_bench.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (barrier_bench.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/gc/finalizer/jbuild.inc
+++ b/examples/code/gc/finalizer/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_finalizer.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_finalizer.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/gc/jbuild.inc
+++ b/examples/code/gc/jbuild.inc
@@ -1,10 +1,19 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (tune.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (tune.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/guided-tour/jbuild.inc
+++ b/examples/code/guided-tour/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (main.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (local_let.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (local_let.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/guided-tour/sum/jbuild.inc
+++ b/examples/code/guided-tour/sum/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_sum.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_sum.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/imperative-programming/jbuild.inc
+++ b/examples/code/imperative-programming/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (for.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,7 +9,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (for.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (order.mlt (files_recursively_in .)))
   (action (
     progn
@@ -17,7 +26,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (order.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (file.mlt (files_recursively_in .)))
   (action (
     progn
@@ -25,7 +43,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (file.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (file2.mlt (files_recursively_in .)))
   (action (
     progn
@@ -33,7 +60,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (file2.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (letrec.mlt (files_recursively_in .)))
   (action (
     progn
@@ -41,7 +77,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (letrec.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (fib.mlt (files_recursively_in .)))
   (action (
     progn
@@ -49,7 +94,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (fib.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (examples.mlt (files_recursively_in .)))
   (action (
     progn
@@ -57,7 +111,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (examples.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (weak.mlt (files_recursively_in .)))
   (action (
     progn
@@ -65,7 +128,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (weak.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (memo.mlt (files_recursively_in .)))
   (action (
     progn
@@ -73,7 +145,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (memo.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (printf.mlt (files_recursively_in .)))
   (action (
     progn
@@ -81,7 +162,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (printf.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (value_restriction.mlt (files_recursively_in .)))
   (action (
     progn
@@ -89,7 +179,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (value_restriction.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (ref.mlt (files_recursively_in .)))
   (action (
     progn
@@ -97,10 +196,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (ref.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (lazy.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (lazy.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/json/github_org_info/jbuild.inc
+++ b/examples/code/json/github_org_info/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (github_org.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (github_org.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/json/jbuild.inc
+++ b/examples/code/json/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (build_json.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,7 +9,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (build_json.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (install.mlt (files_recursively_in .)))
   (action (
     progn
@@ -17,7 +26,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (install.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (build_github_atd.sh (files_recursively_in .)))
   (action (
     progn
@@ -25,10 +43,25 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (build_github_atd.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (parse_book.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (parse_book.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/json/parse_book/jbuild.inc
+++ b/examples/code/json/parse_book/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_parse_book.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_parse_book.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/json/read_json/jbuild.inc
+++ b/examples/code/json/read_json/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_read_json.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_read_json.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/lists-and-patterns/jbuild.inc
+++ b/examples/code/lists-and-patterns/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (main.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (poly.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (poly.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/maps-and-hash-tables/jbuild.inc
+++ b/examples/code/maps-and-hash-tables/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (main.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (core_phys_equal.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (core_phys_equal.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/maps-and-hash-tables/map_vs_hash/jbuild.inc
+++ b/examples/code/maps-and-hash-tables/map_vs_hash/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_map_vs_hash.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_map_vs_hash.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/maps-and-hash-tables/map_vs_hash2/jbuild.inc
+++ b/examples/code/maps-and-hash-tables/map_vs_hash2/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_map_vs_hash2.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (run_map_vs_hash2.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/memory-repr/jbuild.inc
+++ b/examples/code/memory-repr/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (reprs.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (reprs.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (simple_record.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (simple_record.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/objects/jbuild.inc
+++ b/examples/code/objects/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (polymorphism.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,7 +9,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (polymorphism.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (row_polymorphism.mlt (files_recursively_in .)))
   (action (
     progn
@@ -17,7 +26,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (row_polymorphism.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (stack.mlt (files_recursively_in .)))
   (action (
     progn
@@ -25,7 +43,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (stack.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (immutable.mlt (files_recursively_in .)))
   (action (
     progn
@@ -33,10 +60,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (immutable.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (subtyping.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (subtyping.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/ocp-index/jbuild.inc
+++ b/examples/code/ocp-index/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (index_ncurses.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (index_ncurses.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/packing/jbuild.inc
+++ b/examples/code/packing/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_test.sh (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,22 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (build_test.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (show_files.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (show_files.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/parsing-test/jbuild.inc
+++ b/examples/code/parsing-test/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (run_broken_test.errsh (files_recursively_in .)))
   (action (
     progn
@@ -9,10 +9,22 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (run_broken_test.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (build_test.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_test.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/parsing/jbuild.inc
+++ b/examples/code/parsing/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_short_parser.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_short_parser.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/records/jbuild.inc
+++ b/examples/code/records/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,7 +9,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (main.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (main2.mlt (files_recursively_in .)))
   (action (
     progn
@@ -17,10 +26,25 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (main2.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (warn_help.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (warn_help.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/sexpr/jbuild.inc
+++ b/examples/code/sexpr/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (sexp_option.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,7 +9,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (sexp_option.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (manually_making_sexp.mlt (files_recursively_in .)))
   (action (
     progn
@@ -17,7 +26,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (manually_making_sexp.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (inline_sexp.mlt (files_recursively_in .)))
   (action (
     progn
@@ -25,7 +43,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (inline_sexp.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (sexp_default.mlt (files_recursively_in .)))
   (action (
     progn
@@ -33,7 +60,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (sexp_default.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (sexp_printer.mlt (files_recursively_in .)))
   (action (
     progn
@@ -41,7 +77,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (sexp_printer.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (auto_making_sexp.mlt (files_recursively_in .)))
   (action (
     progn
@@ -49,7 +94,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (auto_making_sexp.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (example_load.mlt (files_recursively_in .)))
   (action (
     progn
@@ -57,7 +111,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (example_load.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (to_from_sexp.mlt (files_recursively_in .)))
   (action (
     progn
@@ -65,7 +128,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name cram)
+  (name runtest-all)
+  (deps (to_from_sexp.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (list_top_packages.sh (files_recursively_in .)))
   (action (
     progn
@@ -73,7 +145,13 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (list_top_packages.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (print_sexp.mlt (files_recursively_in .)))
   (action (
     progn
@@ -81,7 +159,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (print_sexp.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (sexp_list.mlt (files_recursively_in .)))
   (action (
     progn
@@ -89,10 +176,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (sexp_list.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (sexp_opaque.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (sexp_opaque.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/sexpr/read_foo/jbuild.inc
+++ b/examples/code/sexpr/read_foo/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_read_foo.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_read_foo.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/sexpr/read_foo_better_errors/jbuild.inc
+++ b/examples/code/sexpr/read_foo_better_errors/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_read_foo_better_errors.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_read_foo_better_errors.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/sexpr/test_interval/jbuild.inc
+++ b/examples/code/sexpr/test_interval/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_test_interval.sh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_test_interval.sh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/sexpr/test_interval_nosexp/jbuild.inc
+++ b/examples/code/sexpr/test_interval_nosexp/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build_test_interval_nosexp.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build_test_interval_nosexp.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/variables-and-functions/jbuild.inc
+++ b/examples/code/variables-and-functions/jbuild.inc
@@ -1,10 +1,19 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (main.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/variants-termcol-annotated/jbuild.inc
+++ b/examples/code/variants-termcol-annotated/jbuild.inc
@@ -1,10 +1,16 @@
 (jbuild_version 1)
 
 (alias (
-  (name cram)
+  (name runtest)
   (deps (build.errsh (files_recursively_in .)))
   (action (
     progn
     (run   cram ${<})
     (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (build.errsh (files_recursively_in .)))
+  (action (
+    progn (run cram --non-deterministic ${<}) (diff? ${<} ${<}.corrected)))))
 

--- a/examples/code/variants/jbuild.inc
+++ b/examples/code/variants/jbuild.inc
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (alias (
-  (name code)
+  (name runtest)
   (deps (logger.mlt (files_recursively_in .)))
   (action (
     progn
@@ -9,7 +9,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (logger.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (main.mlt (files_recursively_in .)))
   (action (
     progn
@@ -17,7 +26,16 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (main.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (catch_all.mlt (files_recursively_in .)))
   (action (
     progn
@@ -25,10 +43,28 @@
     (diff? ${<} ${<}.corrected)))))
 
 (alias (
-  (name code)
+  (name runtest-all)
+  (deps (catch_all.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest)
   (deps (blang.mlt (files_recursively_in .)))
   (action (
     progn
     (setenv OCAMLRUNPARAM "" (run ocaml-topexpect -short-paths -verbose ${<}))
+    (diff? ${<} ${<}.corrected)))))
+
+(alias (
+  (name runtest-all)
+  (deps (blang.mlt (files_recursively_in .)))
+  (action (
+    progn
+    (setenv OCAMLRUNPARAM "" (
+      run ocaml-topexpect -non-deterministic -short-paths -verbose ${<}))
     (diff? ${<} ${<}.corrected)))))
 


### PR DESCRIPTION
- `make run` runs all the determinitic cram and mlt tests;
- `make run-all` run all the cram and mlt tests (including the non-determinitic ones).

This needs #2890 to be merged first (as the two PRs will conflict)