### PR TITLE
Simplify HTML structure

### DIFF
--- a/bin/lib/rwo_book.ml
+++ b/bin/lib/rwo_book.ml
@@ -181,7 +181,7 @@ let make_frontpage ?(repo_root=".") () : Html.t Deferred.t =
   let column3 = [Html.div ~a:["class","index-toc"] (part_items part3)] in
   Html.of_file file >>| fun html ->
   let content =
-    Html.get_body_childs ~filename:file html
+    html
     |> Html.replace_id_node_with ~id:"part1" ~with_:column1
     |> Html.replace_id_node_with ~id:"part2" ~with_:column2
     |> Html.replace_id_node_with ~id:"part3" ~with_:column3
@@ -238,7 +238,6 @@ let make_chapter_page ?code_dir ?pygmentize repo_root chapters chapter_file
   in
 
   Html.of_file chapter_file >>= fun html ->
-  let html = Html.get_body_childs ~filename:chapter_file html in
   Scripts.of_html ?code_dir ~filename:chapter_file html >>|
   ok_exn >>= fun scripts ->
   loop scripts html >>| fun content ->
@@ -259,11 +258,8 @@ let make_simple_page file =
   Html.of_file file >>= fun content ->
   let content = Html.[
     div ~a:["class","left-column"] [];
-    article ~a:["class","main-body"] (
-      get_body_childs ~filename:file content;
-    )
-  ]
-  in
+    article ~a:["class","main-body"] content;
+  ] in
   return (main_template ~title_bar:title_bar ~content ())
 
 

--- a/bin/lib/rwo_html.ml
+++ b/bin/lib/rwo_html.ml
@@ -153,18 +153,6 @@ let fold t ~init ~f =
   in
   List.fold t ~init ~f:loop
 
-let get_childs ~filename tag t =
-  match get_all_nodes tag t with
-  | [] -> failwithf "%s: <%s> not found" filename tag ()
-  | _::_::_ -> failwithf "%s: multiple <%s> tags found" filename tag ()
-  | (`Data _)::[] -> assert false
-  | (`Element {name;childs;_})::[] when name=tag-> childs
-  | (`Element _)::[] -> assert false
-
-let get_body_childs ~filename t =
-  let html = get_childs ~filename "html" t in
-  get_childs ~filename "body" html
-
 let replace_id_node_with t ~id ~with_ =
   let rec loop = function
     | [] -> []

--- a/bin/lib/rwo_html.mli
+++ b/bin/lib/rwo_html.mli
@@ -59,8 +59,6 @@ val filter_whitespace : item list -> item list
 
 val fold : item list -> init:'a -> f:('a -> item -> 'a) -> 'a
 
-val get_body_childs : filename:string -> t -> item list
-
 (** [replace_id_node_with t id with_] searches [t] for a node with
     given [id], and replaces that node entirely with [with_] items. *)
 val replace_id_node_with : t -> id:string -> with_:(item list) -> t

--- a/book/00-prologue.html
+++ b/book/00-prologue.html
@@ -1,14 +1,4 @@
-
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 (experimental) for Mac OS X https://github.com/w3c/tidy-html5/tree/c63cc39"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="prologue" data-type="chapter">
+  <section id="prologue" data-type="chapter">
     <h1>Prologue</h1>
 
     <section id="why-ocaml" data-type="sect1">
@@ -520,5 +510,3 @@
       </ul>
     </section>
   </section>
-</body>
-</html>

--- a/book/01-guided-tour.html
+++ b/book/01-guided-tour.html
@@ -1,14 +1,4 @@
-
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 (experimental) for Mac OS X https://github.com/w3c/tidy-html5/tree/c63cc39"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="a-guided-tour" data-type="chapter">
+  <section id="a-guided-tour" data-type="chapter">
     <h1>A Guided Tour</h1>
 
     <p>This chapter gives an overview of OCaml by walking through a
@@ -1255,5 +1245,3 @@
       as a result.</p>
     </section>
   </section>
-</body>
-</html>

--- a/book/02-variables-and-functions.html
+++ b/book/02-variables-and-functions.html
@@ -1,14 +1,4 @@
-
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 (experimental) for Mac OS X https://github.com/w3c/tidy-html5/tree/c63cc39"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="variables-and-functions" data-type="chapter">
+  <section id="variables-and-functions" data-type="chapter">
     <h1>Variables and Functions</h1>
 
     <p>Variables and functions are fundamental ideas that show up
@@ -1108,5 +1098,3 @@
       </section>
     </section>
   </section>
-</body>
-</html>

--- a/book/03-lists-and-patterns.html
+++ b/book/03-lists-and-patterns.html
@@ -1,14 +1,4 @@
-
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 (experimental) for Mac OS X https://github.com/w3c/tidy-html5/tree/c63cc39"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="lists-and-patterns" data-type="chapter">
+  <section id="lists-and-patterns" data-type="chapter">
     <h1>Lists and Patterns</h1>
 
     <p>This chapter will focus on two common elements of
@@ -802,5 +792,3 @@
       <link rel="import" href="code/lists-and-patterns/main.mlt" part="53"/>
     </section>
   </section>
-</body>
-</html>

--- a/book/04-files-modules-and-programs.html
+++ b/book/04-files-modules-and-programs.html
@@ -1,14 +1,4 @@
-
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 (experimental) for Mac OS X https://github.com/w3c/tidy-html5/tree/c63cc39"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="files-modules-and-programs" data-type="chapter">
+  <section id="files-modules-and-programs" data-type="chapter">
     <h1>Files, Modules, and Programs</h1>
 
     <p>We've so far experienced OCaml largely through the toplevel.
@@ -1028,5 +1018,3 @@
       </section>
     </section>
   </section>
-</body>
-</html>

--- a/book/05-records.html
+++ b/book/05-records.html
@@ -1,14 +1,4 @@
-
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 (experimental) for Mac OS X https://github.com/w3c/tidy-html5/tree/c63cc39"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="records" data-type="chapter">
+  <section id="records" data-type="chapter">
     <h1>Records</h1>
 
     <p>One of OCaml's best features is its concise and expressive
@@ -596,5 +586,3 @@
       considered.<a data-type="indexterm" data-startref="Ffc">&nbsp;</a><a data-type="indexterm" data-startref="firstclass">&nbsp;</a><a data-type="indexterm" data-startref="RECfirstclass">&nbsp;</a></p>
     </section>
   </section>
-</body>
-</html>

--- a/book/06-variants.html
+++ b/book/06-variants.html
@@ -1,14 +1,4 @@
-
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 (experimental) for Mac OS X https://github.com/w3c/tidy-html5/tree/c63cc39"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="variants" data-type="chapter">
+  <section id="variants" data-type="chapter">
     <h1>Variants</h1>
 
     <p>
@@ -744,5 +734,3 @@
       </section>
     </section>
   </section>
-</body>
-</html>

--- a/book/07-error-handling.html
+++ b/book/07-error-handling.html
@@ -1,14 +1,4 @@
-
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta name="generator" content="HTML Tidy for HTML5 (experimental) for Mac OS X https://github.com/w3c/tidy-html5/tree/c63cc39"/>
-
-    <title></title>
-  </head>
-
-  <body>
-    <section xmlns="http://www.w3.org/1999/xhtml" id="error-handling" data-type="chapter">
+    <section id="error-handling" data-type="chapter">
       <h1>Error Handling</h1>
 
       <p>
@@ -827,5 +817,3 @@
 	  right solution.</p>
       </section>
     </section>
-  </body>
-</html>

--- a/book/08-imperative-programming.html
+++ b/book/08-imperative-programming.html
@@ -1,14 +1,4 @@
-
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 (experimental) for Mac OS X https://github.com/w3c/tidy-html5/tree/c63cc39"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="imperative-programming-1" data-type="chapter">
+  <section id="imperative-programming-1" data-type="chapter">
     <h1>Imperative Programming</h1>
 
     <p>
@@ -1866,5 +1856,3 @@
       programming.<a data-type="indexterm" data-startref="PROGimper">&nbsp;</a></p>
     </section>
   </section>
-</body>
-</html>

--- a/book/09-functors.html
+++ b/book/09-functors.html
@@ -1,14 +1,4 @@
-
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 (experimental) for Mac OS X https://github.com/w3c/tidy-html5/tree/c63cc39"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="functors" data-type="chapter">
+  <section id="functors" data-type="chapter">
     <h1>Functors</h1>
 
     <p>
@@ -599,5 +589,3 @@
 	architectures, functors become a highly valuable tool.</p>
     </section>
   </section>
-</body>
-</html>

--- a/book/10-first-class-modules.html
+++ b/book/10-first-class-modules.html
@@ -1,12 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="first-class-modules" data-type="chapter">
+  <section id="first-class-modules" data-type="chapter">
     <h1>First-Class Modules</h1>
 
     <p>
@@ -558,5 +550,3 @@
 	<a data-type="indexterm" data-startref="MODfirst">&nbsp;</a></p>
     </section>
   </section>
-</body>
-</html>

--- a/book/11-objects.html
+++ b/book/11-objects.html
@@ -1,12 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="objects" data-type="chapter">
+  <section id="objects" data-type="chapter">
     <h1>Objects</h1>
 
     <p>
@@ -678,5 +670,3 @@
       </section>
     </section>
   </section>
-</body>
-</html>

--- a/book/12-classes.html
+++ b/book/12-classes.html
@@ -1,12 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-    <title></title>
-  </head>
-
-  <body>
-    <section xmlns="http://www.w3.org/1999/xhtml" id="classes" data-type="chapter">
+    <section id="classes" data-type="chapter">
       <h1>Classes</h1>
 
       <p>
@@ -881,5 +873,3 @@
 	</section>
       </section>
     </section>
-  </body>
-</html>

--- a/book/13-maps-and-hashtables.html
+++ b/book/13-maps-and-hashtables.html
@@ -1,12 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-    <title></title>
-  </head>
-
-  <body>
-    <section xmlns="http://www.w3.org/1999/xhtml" id="maps-and-hash-tables" data-type="chapter">
+    <section id="maps-and-hash-tables" data-type="chapter">
       <h1>Maps and Hash Tables</h1>
 
       <p>
@@ -842,5 +834,3 @@
 	  <idx>equality, tests of</idx></p>
       </section>
     </section>
-  </body>
-</html>

--- a/book/14-command-line-parsing.html
+++ b/book/14-command-line-parsing.html
@@ -1,12 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-    <title></title>
-  </head>
-
-  <body>
-    <section xmlns="http://www.w3.org/1999/xhtml" id="command-line-parsing" data-type="chapter">
+    <section id="command-line-parsing" data-type="chapter">
       <h1>Command-Line Parsing</h1>
 
       <p>
@@ -1164,5 +1156,3 @@
 	</dl>
       </section>
     </section>
-  </body>
-</html>

--- a/book/15-json.html
+++ b/book/15-json.html
@@ -1,12 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-    <title></title>
-  </head>
-
-  <body>
-    <section xmlns="http://www.w3.org/1999/xhtml" id="handling-json-data" data-type="chapter">
+    <section id="handling-json-data" data-type="chapter">
       <h1>Handling JSON Data</h1>
 
       <p>
@@ -969,5 +961,3 @@
 	</section>
       </section>
     </section>
-  </body>
-</html>

--- a/book/16-parsing-with-ocamllex-and-menhir.html
+++ b/book/16-parsing-with-ocamllex-and-menhir.html
@@ -1,12 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-    <title></title>
-  </head>
-
-  <body>
-    <section xmlns="http://www.w3.org/1999/xhtml" id="parsing-with-ocamllex-and-menhir" data-type="chapter">
+    <section id="parsing-with-ocamllex-and-menhir" data-type="chapter">
       <h1>Parsing with OCamllex and Menhir</h1>
 
       <p>
@@ -746,5 +738,3 @@
 	  sophisticated applications.</p>
       </section>
     </section>
-  </body>
-</html>

--- a/book/17-data-serialization.html
+++ b/book/17-data-serialization.html
@@ -1,12 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-    <title></title>
-  </head>
-
-  <body>
-    <section xmlns="http://www.w3.org/1999/xhtml" id="data-serialization-with-s-expressions" data-type="chapter">
+    <section id="data-serialization-with-s-expressions" data-type="chapter">
       <h1>Data Serialization with S-Expressions</h1>
 
       <p>
@@ -711,5 +703,3 @@
 	</section>
       </section>
     </section>
-  </body>
-</html>

--- a/book/18-concurrent-programming.html
+++ b/book/18-concurrent-programming.html
@@ -1,12 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-    <title></title>
-  </head>
-
-  <body>
-    <section xmlns="http://www.w3.org/1999/xhtml" id="concurrent-programming-with-async" data-type="chapter">
+    <section id="concurrent-programming-with-async" data-type="chapter">
       <h1>Concurrent Programming with Async</h1>
 
 
@@ -1575,5 +1567,3 @@
 	</section>
       </section>
     </section>
-  </body>
-</html>

--- a/book/19-foreign-function-interface.html
+++ b/book/19-foreign-function-interface.html
@@ -1,12 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="foreign-function-interface" data-type="chapter">
+  <section id="foreign-function-interface" data-type="chapter">
     <h1>Foreign Function Interface</h1>
 
     <p>OCaml has several options available to interact with
@@ -977,5 +969,3 @@
       </section>
     </section>
   </section>
-</body>
-</html>

--- a/book/20-runtime-memory-layout.html
+++ b/book/20-runtime-memory-layout.html
@@ -1,13 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X
-				    version 4.9.20"/> 
-
-    <title></title>
-  </head>
-
-  <body>
-    <section xmlns="http://www.w3.org/1999/xhtml" id="memory-representation-of-values" data-type="chapter"> 
+    <section id="memory-representation-of-values" data-type="chapter">
       <h1>Memory Representation of Values</h1>
 
       <p>
@@ -867,5 +858,3 @@
 	</section>
       </section>
     </section>
-  </body>
-</html>

--- a/book/21-garbage-collector.html
+++ b/book/21-garbage-collector.html
@@ -1,12 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-    <title></title>
-  </head>
-
-  <body>
-    <section xmlns="http://www.w3.org/1999/xhtml" id="understanding-the-garbage-collector" data-type="chapter">
+    <section id="understanding-the-garbage-collector" data-type="chapter">
       <h1>Understanding the Garbage Collector</h1>
 
       <p>
@@ -875,5 +867,3 @@
 	  with it.</p>
       </section>
     </section>
-  </body>
-</html>

--- a/book/22-compiler-frontend.html
+++ b/book/22-compiler-frontend.html
@@ -1,12 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-  <title></title>
-</head>
-
-<body>
-  <section xmlns="http://www.w3.org/1999/xhtml" id="the-compiler-frontend-parsing-and-type-checking" data-type="chapter">
+  <section id="the-compiler-frontend-parsing-and-type-checking" data-type="chapter">
     <h1>The Compiler Frontend: Parsing and <span class="keep-together">Type Checking</span></h1>
 
     <p>Compiling source code into executable programs is a fairly
@@ -1408,5 +1400,3 @@
       </section>
     </section>
   </section>
-</body>
-</html>

--- a/book/23-compiler-backend.html
+++ b/book/23-compiler-backend.html
@@ -1,11 +1,3 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta name="generator" content="HTML Tidy for HTML5 for Mac OS X version 4.9.20"/>
-
-  <title></title>
-</head>
-
-<body>
   <section id="the-compiler-backend-byte-code-and-native-code" data-type="chapter">
     <h1>The Compiler Backend: Bytecode and Native code</h1>
 
@@ -1082,5 +1074,3 @@
       </table>
     </section>
   </section>
-</body>
-</html>


### PR DESCRIPTION
Remove `<html>` and `<body>` tags from the HTML docs. The goal is to get something simple and consistent that we can then parse and translate to markdown without loosing contents and structure.