### PR TITLE
html2md improvements

### DIFF
--- a/bin/lib/rwo_index.ml
+++ b/bin/lib/rwo_index.ml
@@ -27,7 +27,8 @@ let indexterm_to_idx docs =
             | _ -> true
           )
           in
-          `Element {name="idx"; attrs; childs=[`Data data]}
+          let attrs = ("class", "idx") :: attrs in
+          `Element {name="span"; attrs; childs=[`Data data]}
       )
       else
         item (* no point in recursing to single Data child *)
@@ -40,8 +41,10 @@ let indexterm_to_idx docs =
 let idx_to_indexterm t =
   let rec loop item = match item with
     | `Data _ -> item
-    | `Element {name="idx"; attrs; childs=[`Data data]} -> (
-      match String.split data ~on:'/' with
+    | `Element {name="span"; attrs; childs=[`Data data]}
+      when List.Assoc.find ~equal:(=) attrs "class" = Some "idx"->
+      let attrs = List.filter attrs ~f:(fun (x, _) -> x <> "class") in
+      (match String.split data ~on:'/' with
       | x::[] ->
         `Element {
           name = "a";
@@ -63,8 +66,6 @@ let idx_to_indexterm t =
           "<idx> node's child must be slash separated string but got %s"
           data ()
     )
-    | `Element {name="idx"; _} ->
-      failwith "<idx> node should have single Data child"
     | `Element {name; attrs; childs} ->
       `Element {name; attrs; childs = List.map childs ~f:loop}
   in

--- a/book/19-foreign-function-interface.html
+++ b/book/19-foreign-function-interface.html
@@ -181,7 +181,7 @@
       <link rel="import" href="code/ffi/hello/build_hello.sh"/>
 
       <p>Running <code>./hello.native</code> should now display a
-      Hello World in your terminal!<idx>Ctypes library/build directives for</idx></p>
+      Hello World in your terminal! <idx>Ctypes library/build directives for</idx></p>
 
       <p>Ctypes wouldn't be very useful if it were limited to only
       defining simple C types, of course. It provides full support

--- a/html2md/jbuild
+++ b/html2md/jbuild
@@ -1,4 +1,4 @@
 (executable
   ((name main)
    (public_name html2md)
-   (libraries (fmt lambdasoup))))
+   (libraries (fmt unix lambdasoup))))

--- a/html2md/main.ml
+++ b/html2md/main.ml
@@ -285,7 +285,7 @@ and pp_tip ppf t = pp_part "tip" ppf t
 and pp_caution ppf c = pp_part "caution" ppf c
 
 and pp_section ppf s =
-  Fmt.pf ppf "@[%a %a {#%s data-type=%S}@]@.@.%a@."
+  Fmt.pf ppf "@[%a %a {#%s data-type=%s}@]@.@.%a@."
     pp_level s.level (pp_one_line pp_items)
     s.title s.v.id s.v.data_type pp_block s.body
 

--- a/html2md/main.ml
+++ b/html2md/main.ml
@@ -650,7 +650,7 @@ module Parse = struct
            in
            let v = Soup.classes e = ["allow_break"] in
            let level, title, body = header ~depth e in
-           let level = if level < depth+1 then depth+level else level in
+           let level = if level < depth then depth else level in
            f {level; title; body; v}
          | ["class", "safarienabled"] ->
            Some (`Safari (blocks ~depth (children e)))
@@ -735,13 +735,13 @@ module Parse = struct
 
   and section ~depth ~data_type ~id e =
     let level, title, body = header ~depth e in
-    let level = if level < depth+1 then depth+level else level in
+    let level = if level < depth then depth else level in
     { v = {id; data_type}; level; title; body }
 
   and li e =
     expect "li" (fun e ->
         try para e
-        with Error _ -> blocks ~depth:0 e
+        with Error _ -> blocks ~depth:1 e
       ) e
 
   and dt e = expect "dt" (normalize_items) e
@@ -755,7 +755,7 @@ let of_string str =
   |> Soup.parse
   |> Soup.children
   |> Soup.to_list
-  |> filter_map Parse.(maybe_block ~depth:0)
+  |> filter_map Parse.(maybe_block ~depth:1)
 
 let of_file file =
   file


### PR DESCRIPTION
- trim paragraphs to remove useless spaces
- shorter syntax for idx tags
- add a `--all` options to convert all chapters in one go
- fix renumbering of section headers 