### PR TITLE
Fix rendering of shell snippets

### DIFF
--- a/bin/lib/rwo_scripts.ml
+++ b/bin/lib/rwo_scripts.ml
@@ -141,7 +141,7 @@ let script_part_to_html (x : script_part) =
     | `OCaml_toplevel phrases -> phrases_to_html phrases
     | `OCaml_rawtoplevel x
     | `OCaml x -> Pygments.pygmentize `OCaml x.Expect.Raw_script.content
-    | `Shell x -> Pygments.pygmentize `Bash (Expect.Cram.to_html x)
+    | `Shell x -> Pygments.pygmentize ~interactive:true `Bash (Expect.Cram.to_html x)
     | `Other x -> Pygments.pygmentize `OCaml x
   in
   Html.div ~a:["class","highlight"] [l]


### PR DESCRIPTION
Render:
<img width="810" alt="screen shot 2018-04-03 at 13 01 00" src="https://user-images.githubusercontent.com/103693/38245618-27cf0b3e-373f-11e8-9933-7e62c734727c.png">

instead of the (broken):

<img width="811" alt="screen shot 2018-04-03 at 13 01 17" src="https://user-images.githubusercontent.com/103693/38245624-2f37c6ea-373f-11e8-97d9-043bb22746c5.png">



