### PR TITLE
Fix broken syntax highlighting caused by empty shell scripts

### DIFF
--- a/bin/lib/expect.ml
+++ b/bin/lib/expect.ml
@@ -58,6 +58,7 @@ module Cram = struct
   type t = Cram.t [@@deriving sexp]
   let to_html x = Cram.to_html x
   let part = Cram.part
+  let is_empty t = t = []
 
   let of_file ~filename =
     Monitor.try_with_or_error (fun () -> Reader.file_contents filename)

--- a/bin/lib/expect.mli
+++ b/bin/lib/expect.mli
@@ -22,6 +22,7 @@ end
 
 module Cram: sig
   type t [@@deriving sexp]
+  val is_empty: t -> bool
   val to_html: t -> string
   val part: string -> t -> t option
   val of_file: filename:string -> t Deferred.Or_error.t

--- a/bin/lib/scripts.ml
+++ b/bin/lib/scripts.ml
@@ -136,7 +136,9 @@ let script_part_to_html (x : script_part) =
     | `OCaml_toplevel phrases -> phrases_to_html phrases
     | `OCaml_rawtoplevel x
     | `OCaml x -> Pygments.pygmentize `OCaml x.Expect.Raw_script.content
-    | `Shell x -> Pygments.pygmentize ~interactive:true `Bash (Expect.Cram.to_html x)
+    | `Shell x ->
+      if Expect.Cram.is_empty x then `Data ""
+      else Pygments.pygmentize ~interactive:true `Bash (Expect.Cram.to_html x)
     | `Other x -> Pygments.pygmentize `OCaml x
   in
   Html.div ~a:["class","highlight"] [l]
@@ -174,6 +176,8 @@ let script lang ~filename =
     )
   | "sh" | "errsh" -> (
       let %map script = Expect.Cram.of_file ~filename in
+      if Expect.Cram.is_empty script then
+        printf "warning: %s is empty\n%!" filename;
       `Shell script
     )
   | "jbuild" ->


### PR DESCRIPTION
Fix #2960