### PR TITLE
css: fix display of warning boxes

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1262,26 +1262,46 @@
      padding-top: 0;
      border-top: 0;
 }
+
+ /* Notes & Warnings */
  section[data-type=chapter] div[data-type=note] {
      background: #fdedd4;
      border: 1px solid #f39c12;
+ }
+ section[data-type=chapter] div[data-type=warning] {
+     background: #F2D7D5;
+     border: 1px solid #F1948A;
+ }
+
+ section[data-type=chapter] div[data-type=note],
+ section[data-type=chapter] div[data-type=warning] {
      border-radius: 3px;
      margin-bottom: 1.6875rem;
      padding: 1.6875rem;
 }
  section[data-type=chapter] div[data-type=note] h1,
- section[data-type=chapter] div[data-type=note] h2 {
+ section[data-type=chapter] div[data-type=note] h2,
+ section[data-type=chapter] div[data-type=warning] h1,
+ section[data-type=chapter] div[data-type=warning] h2 {
      font-size: 1.5625rem;
 }
- section[data-type=chapter] div[data-type=note] p {
+ section[data-type=chapter] div[data-type=note] p,
+ section[data-type=chapter] div[data-type=warning] p {
+     font-size: 0.875rem;
      font-family: "proxima-nova", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+     font-weight: normal;
 }
- section[data-type=chapter] div[data-type=note] pre, section[data-type=chapter] div[data-type=note] div.highlight {
+ section[data-type=chapter] div[data-type=note] pre,
+ section[data-type=chapter] div[data-type=note] div.highlight,
+ section[data-type=chapter] div[data-type=warning] pre,
+ section[data-type=chapter] div[data-type=warning] div.highlight {
      background: transparent;
 }
- section[data-type=chapter] div[data-type=note] div.highlight {
+ section[data-type=chapter] div[data-type=note] div.highlight,
+ section[data-type=chapter] div[data-type=warning] div.highlight {
      padding: 0 1.6875rem;
 }
+
  section[data-type=chapter] aside {
      margin-left: -1.6875rem;
      margin-right: -1.6875rem;


### PR DESCRIPTION
Fix #2880

The new rendering:

<img width="845" alt="screen shot 2018-06-01 at 10 42 35" src="https://user-images.githubusercontent.com/103693/40831174-980cfdee-6588-11e8-946c-0898ff62b8a0.png">

That commit also change the font size of "note" boxes to be the same as the "sidebar" and "warning" ones. I still have no idea what the sidebar boxes are about, and why they are treated differently (e.g. they are in a `<aside>` tag instead of a `<div>`) :-) We could probably improve all of that by treating all these boxes almost the same. Just let me know what you prefer.