### PR TITLE
Correction of some exercises with a failed build

### DIFF
--- a/book/runtime-memory-layout.md
+++ b/book/runtime-memory-layout.md
@@ -371,7 +371,7 @@ A polymorphic variant without any parameters is stored as an unboxed integer
 and so only takes up one word of memory, just like a normal variant. This
 integer value is determined by applying a hash function to the *name* of the
 variant. The hash function isn't exposed directly by the compiler, but the
-`type_conv` library from Core provides an alternative implementation:
+`typerep` library from Core provides an alternative implementation:
 
 <link rel="import" href="code/memory-repr/reprs.mlt" part="6" />
 

--- a/examples/code/async/echo/run_echo.sh
+++ b/examples/code/async/echo/run_echo.sh
@@ -1,8 +1,8 @@
   $ dune build echo.exe
   $ ./_build/default/echo.exe &
   $ sleep 1
-  $ echo "This is an echo server" | nc 127.0.0.1 8765
+  $ echo "This is an echo server" | nc -N 127.0.0.1 8765
   This is an echo server
-  $ echo "It repeats whatever I write" | nc 127.0.0.1 8765
+  $ echo "It repeats whatever I write" | nc -N 127.0.0.1 8765
   It repeats whatever I write
   $ killall -9 echo.exe

--- a/examples/code/command-line-parsing/md5_let_syntax2/md5.sh
+++ b/examples/code/command-line-parsing/md5_let_syntax2/md5.sh
@@ -1,3 +1,4 @@
   $ dune build md5.exe
+%% --non-deterministic
   $ ./_build/default/md5.exe 5 ./_build/default/md5.exe
   8ff8c

--- a/examples/code/command-line-parsing/md5_let_syntax2/md5.sh
+++ b/examples/code/command-line-parsing/md5_let_syntax2/md5.sh
@@ -1,3 +1,3 @@
   $ dune build md5.exe
   $ ./_build/default/md5.exe 5 ./_build/default/md5.exe
-  45a17
+  8ff8c

--- a/examples/code/ffi/ncurses/ncurses.ml
+++ b/examples/code/ffi/ncurses/ncurses.ml
@@ -7,37 +7,39 @@ let window : window typ = ptr void
 [@@@part "1"];;
 open Foreign
 
+let libncurses = Dl.(dlopen ~filename:"libncursesw.so" ~flags:[RTLD_NOW])
+
 let initscr =
-  foreign "initscr" (void @-> returning window)
+  foreign "initscr" (void @-> returning window) ~from:libncurses
 
 
 [@@@part "2"];;
 let newwin =
-  foreign "newwin" 
+  foreign "newwin"  ~from:libncurses
     (int @-> int @-> int @-> int @-> returning window)
 
 let endwin =
-  foreign "endwin" (void @-> returning void)
+  foreign "endwin" (void @-> returning void) ~from:libncurses
 
 let refresh =
-  foreign "refresh" (void @-> returning void)
+  foreign "refresh" (void @-> returning void) ~from:libncurses
 
 let wrefresh =
-  foreign "wrefresh" (window @-> returning void)
+  foreign "wrefresh" (window @-> returning void) ~from:libncurses
 
 let addstr =
-  foreign "addstr" (string @-> returning void)
+  foreign "addstr" (string @-> returning void) ~from:libncurses
 
 let mvwaddch =
-  foreign "mvwaddch"
+  foreign "mvwaddch" ~from:libncurses
     (window @-> int @-> int @-> char @-> returning void)
 
 let mvwaddstr =
-  foreign "mvwaddstr"
+  foreign "mvwaddstr" ~from:libncurses
     (window @-> int @-> int @-> string @-> returning void)
 
 let box =
-  foreign "box" (window @-> char @-> char @-> returning void)
+  foreign "box" (window @-> char @-> char @-> returning void) ~from:libncurses
 
 let cbreak =
-  foreign "cbreak" (void @-> returning int)
+  foreign "cbreak" (void @-> returning int) ~from:libncurses

--- a/examples/code/files-modules-and-programs/freq-with-missing-def/build.errsh
+++ b/examples/code/files-modules-and-programs/freq-with-missing-def/build.errsh
@@ -1,6 +1,6 @@
   $ dune build freq.bc
         ocamlc .freq.eobjs/counter.{cmo,cmt} (exit 2)
-  (cd _build/default && /home/christophe/.opam/rwo/bin/ocamlc.opt -w -40 -g -bin-annot -I .freq.eobjs -I /home/christophe/.opam/rwo/lib/base -I /home/christophe/.opam/rwo/lib/base/caml -I /home/christophe/.opam/rwo/lib/base/shadow_stdlib -I /home/christophe/.opam/rwo/lib/sexplib0 -I /home/christophe/.opam/rwo/lib/stdio -no-alias-deps -o .freq.eobjs/counter.cmo -c -impl counter.ml)
+  (cd _build/default && /home/christophe/.opam/rwo/bin/ocamlc.opt -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -bin-annot -I .freq.eobjs -I /home/christophe/.opam/rwo/lib/base -I /home/christophe/.opam/rwo/lib/base/caml -I /home/christophe/.opam/rwo/lib/base/shadow_stdlib -I /home/christophe/.opam/rwo/lib/sexplib0 -I /home/christophe/.opam/rwo/lib/stdio -intf-suffix .ml -no-alias-deps -opaque -o .freq.eobjs/counter.cmo -c -impl counter.ml)
   File "counter.ml", line 1:
   Error: The implementation counter.ml
          does not match the interface .freq.eobjs/counter.cmi:

--- a/examples/code/files-modules-and-programs/freq-with-missing-def/build.errsh
+++ b/examples/code/files-modules-and-programs/freq-with-missing-def/build.errsh
@@ -1,4 +1,9 @@
-  $ dune build counter.bc
-  Don't know how to build counter.bc
-  Hint: did you mean counter.ml?
+  $ dune build freq.bc
+        ocamlc .freq.eobjs/counter.{cmo,cmt} (exit 2)
+  (cd _build/default && /home/christophe/.opam/rwo/bin/ocamlc.opt -w -40 -g -bin-annot -I .freq.eobjs -I /home/christophe/.opam/rwo/lib/base -I /home/christophe/.opam/rwo/lib/base/caml -I /home/christophe/.opam/rwo/lib/base/shadow_stdlib -I /home/christophe/.opam/rwo/lib/sexplib0 -I /home/christophe/.opam/rwo/lib/stdio -no-alias-deps -o .freq.eobjs/counter.cmo -c -impl counter.ml)
+  File "counter.ml", line 1:
+  Error: The implementation counter.ml
+         does not match the interface .freq.eobjs/counter.cmi:
+         The value `count' is required but not provided
+         File "counter.mli", line 18, characters 0-30: Expected declaration
 @@ exit 1

--- a/examples/code/files-modules-and-programs/freq-with-missing-def/build.errsh
+++ b/examples/code/files-modules-and-programs/freq-with-missing-def/build.errsh
@@ -1,6 +1,6 @@
   $ dune build freq.bc
         ocamlc .freq.eobjs/counter.{cmo,cmt} (exit 2)
-  (cd _build/default && /home/christophe/.opam/rwo/bin/ocamlc.opt -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -bin-annot -I .freq.eobjs -I /home/christophe/.opam/rwo/lib/base -I /home/christophe/.opam/rwo/lib/base/caml -I /home/christophe/.opam/rwo/lib/base/shadow_stdlib -I /home/christophe/.opam/rwo/lib/sexplib0 -I /home/christophe/.opam/rwo/lib/stdio -intf-suffix .ml -no-alias-deps -opaque -o .freq.eobjs/counter.cmo -c -impl counter.ml)
+  ...
   File "counter.ml", line 1:
   Error: The implementation counter.ml
          does not match the interface .freq.eobjs/counter.cmi:

--- a/examples/code/files-modules-and-programs/freq-with-missing-def/counter.ml
+++ b/examples/code/files-modules-and-programs/freq-with-missing-def/counter.ml
@@ -1,1 +1,15 @@
-type t
+open Base
+
+type t = int Map.M(String).t
+
+let empty = Map.empty (module String)
+
+let to_list t = Map.to_alist t
+
+let touch t s =
+  let count =
+    match Map.find t s with
+    | None -> 0
+    | Some x -> x
+  in
+  Map.set t ~key:s ~data:(count + 1)

--- a/examples/code/files-modules-and-programs/freq-with-missing-def/counter.mli
+++ b/examples/code/files-modules-and-programs/freq-with-missing-def/counter.mli
@@ -1,4 +1,18 @@
+open Base
+
+(** A collection of string frequency counts *)
 type t
+
+(** The empty set of frequency counts  *)
+val empty : t
+
+(** Bump the frequency count for the given string. *)
+val touch : t -> string -> t
+
+(** Converts the set of frequency counts to an association list.  A string shows
+    up at most once, and the counts are >= 1. *)
+val to_list : t -> (string * int) list
+
 
 [@@@part "1"]
 val count : t -> string -> int

--- a/examples/code/front-end/camlp4_toplevel.mlt
+++ b/examples/code/front-end/camlp4_toplevel.mlt
@@ -9,11 +9,12 @@
 #use "topfind" ;;
 #camlp4o ;;
 [@@@part "1"];;
-#require "comparelib.syntax" ;;
+open Core_kernel;;
+#require "ppx_compare" ;;
 type t = { foo: string; bar : t } ;;
 [%%expect ocaml {|type t = { foo : string; bar : t; }|}];;
 type t = { foo: string; bar: t } [@@deriving compare] ;;
-[%%expect{|
-Characters 16-22:
-Error: Unbound value compare_string
+[%%expect ocaml {|
+type t = { foo : string; bar : t; }
+val compare : t -> t -> int = <fun>
 |}];;

--- a/examples/code/front-end/process_comparelib_test.sh
+++ b/examples/code/front-end/process_comparelib_test.sh
@@ -1,4 +1,9 @@
-  $ ocamlfind ocamlc -package ppx_compare -package core_kernel -dsource -linkpkg comparelib_test.ml
+  $ ocamlfind ocamlc -package ppx_compare -package core_kernel -dsource -linkpkg comparelib_test.mli comparelib_test.ml
+  open Core_kernel
+  type t = {
+    foo: string ;
+    bar: t }[@@deriving compare]
+  include sig [@@@ocaml.warning "-32"] val compare : t -> t -> int end
   open Core_kernel
   type t = {
     foo: string ;
@@ -14,6 +19,3 @@
             | 0 -> compare a__001_.bar b__002_.bar
             | n -> n) : t -> t -> int)
   let _ = compare
-  File "comparelib_test.ml", line 1:
-  Error: Could not find the .cmi file for interface comparelib_test.mli.
-@@ exit 2

--- a/examples/code/json/github_org_info/github_org.sh
+++ b/examples/code/json/github_org_info/github_org.sh
@@ -11,7 +11,7 @@
   $ dune build github_org_j.mli
   $ cat _build/default/github_org_j.mli
   (* Auto-generated from "github_org.atd" *)
-  
+  [@@@ocaml.warning "-27-32-35-39"]
   
   type org = Github_org_t.org = {
     login: string;
@@ -47,7 +47,7 @@
   $ dune build github_org_t.mli
   $ cat _build/default/github_org_t.mli
   (* Auto-generated from "github_org.atd" *)
-  
+                [@@@ocaml.warning "-27-32-35-39"]
   
   type org = {
     login: string;

--- a/examples/code/memory-repr/reprs.mlt
+++ b/examples/code/memory-repr/reprs.mlt
@@ -52,10 +52,7 @@ Obj.tag (Obj.repr (Pear "xyz")) ;;
 (Obj.magic (Obj.field (Obj.repr (Pear "xyz")) 0) : string) ;;
 [%%expect ocaml {|- : string = "xyz"|}];;
 [@@@part "6"];;
-Pa_type_conv.hash_variant "Foo" ;;
-[%%expect{|
-Characters 0-25:
-Error: Unbound module Pa_type_conv
-|}];;
+Typerep_lib__Typerep_obj.hash_variant "Foo" ;;
+[%%expect ocaml {|- : int = 3505894|}];;
 (Obj.magic (Obj.repr `Foo) : int) ;;
 [%%expect ocaml {|- : int = 3505894|}];;

--- a/examples/code/parsing-test/run_broken_test.errsh
+++ b/examples/code/parsing-test/run_broken_test.errsh
@@ -5,6 +5,7 @@
   { "name": "New York",
     "zips": [10004]
   }
+  $ dune build test.exe
   $ ./_build/default/test.exe test2.json
   sh: ./_build/default/test.exe: No such file or directory
 @@ exit 127

--- a/examples/code/parsing-test/run_broken_test.errsh
+++ b/examples/code/parsing-test/run_broken_test.errsh
@@ -7,5 +7,5 @@
   }
   $ dune build test.exe
   $ ./_build/default/test.exe test2.json
-  sh: ./_build/default/test.exe: No such file or directory
-@@ exit 127
+  test2.json:3:2: syntax error
+@@ exit 255

--- a/examples/code/variables-and-functions/main.mlt
+++ b/examples/code/variables-and-functions/main.mlt
@@ -182,9 +182,8 @@ let (+!) (x1,y1) (x2,y2) = (x1 + x2, y1 + y2);;
 [@@@part "27"];;
 let (***) base exponent = (base **. exponent) **. exponent;;
 [%%expect{|
-Characters 17-18:
-Error: This expression has type int but an expression was expected of type
-         float
+Characters 27-31:
+Error: Unbound value base
 |}];;
 [@@@part "28"];;
 let ( *** ) base exponent = (base **. exponent) **. exponent;;

--- a/examples/code/variables-and-functions/main.mlt
+++ b/examples/code/variables-and-functions/main.mlt
@@ -180,14 +180,14 @@ let (+!) (x1,y1) (x2,y2) = (x1 + x2, y1 + y2);;
 (3,2) +! (-2,4);;
 [%%expect ocaml {|- : int * int = (1, 6)|}];;
 [@@@part "27"];;
-let (***) x y = (x **. y) **. y;;
+let (***) base exponent = (base **. exponent) **. exponent;;
 [%%expect{|
 Characters 17-18:
 Error: This expression has type int but an expression was expected of type
          float
 |}];;
 [@@@part "28"];;
-let ( *** ) x y = (x **. y) **. y;;
+let ( *** ) base exponent = (base **. exponent) **. exponent;;
 [%%expect ocaml {|val ( *** ) : float -> float -> float = <fun>|}];;
 [@@@part "29"];;
 Int.max 3 (-4);;

--- a/rwo.opam
+++ b/rwo.opam
@@ -1,16 +1,17 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name: "rwo"
 version: "dev"
 maintainer: "Anil Madhavapeddy <anil@recoil.org>"
 homepage: "https://github.com/realworldocaml/book"
 license: "ISC"
 authors: ["Yaron Minsky" "Anil Madhavapeddy" "Jason Hickey"]
-dev-repo: "https://github.com/realworldocaml/book.git"
+dev-repo: "git://github.com/realworldocaml/book.git"
 bug-reports: "https://github.com/realworldocaml/book/issues"
 
 build: [ "jbuilder" "build" ]
 
 depends: [
+  "ocaml" {>= "4.06.0"}
   "core" {>="v0.11.0"}
   "async" {>="v0.11.0"}
   "ppx_sexp_conv" {build & >="v0.9.0"}
@@ -32,15 +33,16 @@ depends: [
   "atd"
   "atdgen"
   "ctypes"
+  "async_graphics"
   "ctypes-foreign"
   "textwrap"
   "uri"
+]
+pin-depends: [
+ ["async_graphic.dev" "git://github.com/drewsdunne/async_graphics.git"]
 ]
 depexts: [
  [["ubuntu"] ["tzdata"]]
  [["debian"] ["tzdata"]]
  [["alpine"] ["tzdata"]]
-]
-available: [
-  ocaml-version >= "4.06.0"
 ]


### PR DESCRIPTION
Title is explicit and most changes are also. Couple of notes : 

- async_graphics was incompatible with core 0.11 but @drewsdunne did all the job of updating it. I added an updated opam file and it was good to go, so I pinned my repository using opam 2 `pin-depend`. It requires opam 2 though.

- I changed the names of the variables because `x` and `y` were already bound and the error message was not representative of what a user would see in: 
https://github.com/realworldocaml/book/compare/master...christophe-riolo:master#diff-675913d9cf8eb716b98f5f1e08c0a3b3
