### PR TITLE
Compact style

### DIFF
--- a/book/install.html
+++ b/book/install.html
@@ -38,7 +38,7 @@
 
   <p>Let's get started.</p>
 
-  <h1>Getting OPAM</h1>
+  <h2>Getting OPAM</h2>
 
   <p>The easiest way to install OPAM is through your OS's package
   manager. In most cases, installing OPAM will also trigger the
@@ -48,7 +48,7 @@
 
   <p>Here are platform-specific instructions.</p>
 
-  <h2>Mac OS X</h2>
+  <h3>Mac OS X</h3>
 
   <p>If you don't already have a package manager set up, try
   installing homebrew. You can find information on installing
@@ -68,7 +68,7 @@ brew install opam
 sudo port install opam
 </code></pre>
 
-  <h2>Ubuntu Linux</h2>
+  <h3>Ubuntu Linux</h3>
 
   <p>14.04 and higher comes with recent versions of OCaml  and opam. No PPA
   needed.</p>
@@ -76,14 +76,14 @@ sudo port install opam
 sudo apt-get install curl build-essential m4 zlib1g-dev libssl-dev ocaml ocaml-native-compilers opam
 </code></pre>
 
-  <h2>Debian Linux</h2>
+  <h3>Debian Linux</h3>
 
   <p>Debian's OCaml packages aren't yet at 4.06.0, and so you will
   need to compile it from sources. If you are using the
   Debian 9 <code>stable</code> stream, then OPAM 1.2.2 will
   be available.</p>
 
-  <h2>Arch Linux</h2>
+  <h3>Arch Linux</h3>
 
   <p>OPAM is available from the AUR (Arch User Repository). You can
   install OPAM using <code>yaourt</code>:</p>
@@ -100,7 +100,7 @@ makepkg
 sudo pacman -U opam-&lt;version&gt;.pkg.tar.xz
 </code></pre>
 
-  <h2>Building from source</h2>
+  <h3>Building from source</h3>
 
   <p>On platforms not listed above, you'll need to install OPAM
   from source, and to do that you'll need OCaml installed first.
@@ -125,7 +125,7 @@ sudo make install
   <p>If you have problems with any of the above, read the
   <code>INSTALL</code> file in the tar file.</p>
 
-  <h3>Installing OCaml locally</h3>
+  <h4>Installing OCaml locally</h4>
 
   <p>The installation step described above requires administrator
   privileges. You can also install it in your home directory by
@@ -142,7 +142,7 @@ sudo make install
   have special reasons, so try to install binary packages before
   trying a source installation.</p>
 
-  <h3>Installing OPAM</h3>
+  <h4>Installing OPAM</h4>
 
   <p>If the binary packages aren't available for your system,
   you'll need to install the latest OPAM release from source. You
@@ -150,7 +150,7 @@ sudo make install
   "http://opam.ocaml.org/doc/Quick_Install.html">quick install
   guide</a>.</p>
 
-  <h1>Configuring OPAM</h1>
+  <h2>Configuring OPAM</h2>
 
   <p>The entire OPAM package database is held in the
   <code>.opam</code> directory in your home directory, including
@@ -290,7 +290,7 @@ opam install async yojson core_extended core_bench cohttp async_graphics cryptok
   this set up as part of your shell init scripts, as described
   earlier.</p>
 
-  <h1>Setting up and using <code>utop</code></h1>
+  <h2>Setting up and using <code>utop</code></h2>
 
   <p>When you first run <code>utop</code>, you'll find yourself at
   an interactive prompt with a bar at the bottom of the screen. The
@@ -335,9 +335,9 @@ open Core
   remember to open it before running any of the interactive
   examples in the book.</p>
 
-  <h1>Editors</h1>
+  <h2>Editors</h2>
 
-  <h2>Emacs</h2>
+  <h3>Emacs</h3>
 
   <p>These instructions have been tested on emacs 24.2 and should
   work for that version and newer. There are some reports of
@@ -401,7 +401,7 @@ open Core
   "https://github.com/diml/utop#integration-with-emacs">utop
   homepage</a>.</p>
 
-  <h3>Using Emacs24 packages</h3>
+  <h4>Using Emacs24 packages</h4>
 
   <p>As an alternative to the setup above, here is a simplified
   OCaml setup using <a href="http://melpa.milkbox.net/#/">MELPA</a>
@@ -433,14 +433,14 @@ open Core
 (setq merlin-error-after-save nil)
 </code></pre>
 
-  <h2>Vim</h2>
+  <h3>Vim</h3>
 
   <p>Vim users can use the built-in style, and <a href=
   "http://github.com/avsm/ocaml-annot">ocaml-annot</a> may also be
   useful. For a more richly-featured setup, see the section on
   Merlin below.</p>
 
-  <h2>Eclipse</h2>
+  <h3>Eclipse</h3>
 
   <p>Eclipse is a popular IDE usually used for Java development.
   The <a href="http://ocamldt.free.fr">OCaml Development Tools
@@ -449,13 +449,13 @@ open Core
   completion. Installation instructions can be found <a href=
   "http://ocamldt.free.fr/spip.php?article5">here</a></p>
 
-  <h2>Other editors</h2>
+  <h3>Other editors</h3>
 
   <p>There are lots of other editors, and many of them come with
   built-in OCaml modes. These includes TextMate and Sublime Text
   for the Mac, and countless others.</p>
 
-  <h2>Cross-editor tools</h2>
+  <h3>Cross-editor tools</h3>
 
   <p>There are a number of tools that are compatible with multiple
   editors that can help you work more effectively with OCaml. Two
@@ -464,7 +464,7 @@ open Core
   optional. You might want to get started with the book before
   getting back to setting these up.</p>
 
-  <h3>Merlin</h3>
+  <h4>Merlin</h4>
 
   <p>Merlin provides a number of advanced IDE-like features,
   including:</p>
@@ -488,7 +488,7 @@ opam install merlin
   following examples assume Merlin has been installed through OPAM
   as above.</p>
 
-  <h4>Emacs</h4>
+  <h5>Emacs</h5>
 
   <p>A summary follows -- for more complete information, see
   <a href=
@@ -540,7 +540,7 @@ opam install merlin
     confused</li>
   </ul>
 
-  <h4>Vim</h4>
+  <h5>Vim</h5>
 
   <p>A summary follows -- for more complete information, see
   <a href=
@@ -600,7 +600,7 @@ endif
   such as Syntastic and neocomplcache -- see <code>:help
   merlin.txt</code> for pointers.</p>
 
-  <h4>Tell Merlin about your project layout</h4>
+  <h5>Tell Merlin about your project layout</h5>
 
   <p>Regardless of which editor you use, you need to tell Merlin a
   bit about the build environment you're working with in order for
@@ -621,9 +621,9 @@ EXT nonrec
   <p>See the Merlin README for complete details of the file
   format.</p>
 
-  <h3><a id="user-content-ocp-indent" class="anchor" href=
+  <h4><a id="user-content-ocp-indent" class="anchor" href=
   "#ocp-indent" aria-hidden="true" name=
-  "user-content-ocp-indent"></a>ocp-indent</h3>
+  "user-content-ocp-indent"></a>ocp-indent</h4>
 
   <p><code>ocp-indent</code> is a source-code indenter which
   includes a command-line tool, library and integration with emacs
@@ -637,7 +637,7 @@ EXT nonrec
 opam install ocp-indent
 </code></pre>
 
-  <h4>Emacs</h4>
+  <h5>Emacs</h5>
 
   <p>After installing through OPAM, simply load the file as follows
   to override tuareg-mode's indentation:</p>
@@ -646,7 +646,7 @@ opam install ocp-indent
 (load-file (concat opam-share "/typerex/ocp-indent/ocp-indent.el"))
 </code></pre>
 
-  <h4>Vim</h4>
+  <h5>Vim</h5>
 
   <p>After installing through OPAM, simply add this
   <code>autocmd</code> to your Vim configuration:</p>

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -265,19 +265,49 @@
  p {
      font-family: inherit;
      font-weight: 300;
-     font-size: 1.2rem;
-     line-height: 1.5;
+     font-size: 1rem;
+     line-height: 1.4;
      margin-bottom: 1.25rem;
      text-rendering: optimizeLegibility;
+     max-width: 750px;
 }
  p.lead {
-     font-size: 1.41875rem;
+     font-size: 1.5rem;
      line-height: 1.6;
 }
  p aside {
-     font-size: 0.875rem;
      line-height: 1.35;
      font-style: italic;
+ }
+
+ h1 {
+    font-size:32px;
+    font-size:2rem;     /* 32px */
+    line-height:1.5;    /* 48px */
+}
+h2 {
+    font-size:1.5em;    /* 24px */
+    line-height:1;      /* 24px */
+}
+h3 {
+    font-size:20px;
+    font-size:1.25rem;  /* 20px */
+    line-height:1.2;    /* 24px */
+}
+h4 {
+    font-size:18px;
+    font-size:1.125rem; /* 18px */
+    line-height:1.333;  /* 24px */
+}
+h5 {
+    font-size:16px;
+    font-size:1rem;     /* 16px */
+    line-height:1.5;    /* 24px */
+}
+h6 {
+    font-size:16px;
+    font-size:1rem;     /* 16px */
+    line-height:1.5;    /* 24px */
 }
 /* Default header styles */
  h1, h2, h3, h4, h5, h6 {
@@ -294,21 +324,6 @@
      font-size: 40%;
      color: #6f6f6f;
      line-height: 0;
-}
- h1, h2 {
-     font-size: 1.48926rem;
-}
- h3 {
-     font-size: 1.19141rem;
-}
- h4 {
-     font-size: 1.0505rem;
-}
- h5 {
-     font-size: 1.1rem;
-}
- h6 {
-     font-size: 0.875rem;
 }
  .subheader {
      line-height: 1.4;
@@ -345,12 +360,15 @@
      border-width: 0;
      border-style: solid;
      border-color: #adadad;
+     border-radius: 3px;
      padding: 0;
+     line-height: 1.2;
+     vertical-align: baseline;
+     text-transform: none !important;
 }
 /* Lists */
  ul, ol, dl {
-     font-size: 1.2rem;
-     line-height: 1.8;
+     line-height: 1.5;
      margin-bottom: 1.25rem;
      list-style-position: inside;
      font-family: inherit;
@@ -408,7 +426,7 @@
 /* Abbreviations */
  abbr, acronym {
      text-transform: uppercase;
-     font-size: 90%;
+     font-size: 80%;
      color: #444444;
      border-bottom: 1px dotted #dddddd;
      cursor: help;
@@ -424,7 +442,7 @@
 }
  blockquote cite {
      display: block;
-     font-size: 0.8125rem;
+     font-size: 80%;
      color: #555555;
 }
  blockquote cite:before {
@@ -450,7 +468,7 @@
 }
  .vcard .fn {
      font-weight: bold;
-     font-size: 0.9375rem;
+     font-size: 80%;
 }
  .vevent .summary {
      font-weight: bold;
@@ -465,21 +483,6 @@
  @media only screen and (min-width: 40.063em) {
      h1, h2, h3, h4, h5, h6 {
          line-height: 1;
-    }
-     h1, h2 {
-         font-size: 3.05176rem;
-    }
-     h3 {
-         font-size: 2.44141rem;
-    }
-     h4 {
-         font-size: 1.5625rem;
-    }
-     h5 {
-         font-size: 1.25rem;
-    }
-     h6 {
-         font-size: 1rem;
     }
 }
 /* * Print styles. * * Inlined to avoid required HTTP connection: www.phpied.com/delay-loading-your-print-css/ * Credit to Paul Irish and HTML5 Boilerplate (html5boilerplate.com) */
@@ -575,15 +578,8 @@
 }
  @media only screen and (max-width: 40em) {
      p, pre, ul, ol, dl {
-         font-size: 0.875rem;
+         font-size: 80%;
     }
-}
- code {
-     border-radius: 3px;
-     line-height: 1.2;
-     vertical-align: baseline;
-     text-transform: none !important;
-     font-size: 95%;
 }
  a h1, a h2 {
      color: #8e44ad;
@@ -702,6 +698,7 @@
      .title-bar {
          background: url("../images/book-cover.jpg") no-repeat, #424b50 url("../images/bg.jpg") repeat;
          background-size: auto 100%, auto;
+         padding-left: 20%;
     }
      .title-bar .title {
          padding-left: 1.6875rem;
@@ -778,7 +775,7 @@
      font-weight: normal;
      color: white;
      text-transform: uppercase;
-     font-size: 0.875rem;
+     font-size: 80%;
      display: inline-block;
      margin-right: 0.5rem;
      margin-bottom: 0.5rem;
@@ -840,9 +837,6 @@
      float: none;
      padding-bottom: 1.6875rem;
 }
- .splash .title h1 {
-     font-size: 1.86157rem;
-}
  @media only screen and (min-width: 40.063em) {
      .splash {
          display: table;
@@ -872,11 +866,6 @@
          background: transparent;
     }
 }
- @media only screen and (min-width: 64.063em) {
-     .splash .title h1 {
-         font-size: 3.8147rem;
-    }
-}
  .toc {
      list-style: none;
      margin: 0;
@@ -903,12 +892,6 @@
 }
  .toc > li a h2 {
      margin: 0;
-     font-size: 1.5625rem;
-}
- @media only screen and (max-width: 40em) {
-     .toc > li a h2 {
-         font-size: 1.36719rem;
-    }
 }
  .toc > li a h2 small {
      display: block;
@@ -931,7 +914,6 @@
      font-style: normal;
      content: '+';
      font-color: #6f6f6f;
-     font-size: 1.4rem;
      text-align: center;
      line-height: 1.8rem;
      cursor: pointer;
@@ -963,7 +945,6 @@
      font-weight: 300;
      font-family: "proxima-nova", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
      font-style: italic;
-     font-size: 1rem;
      color: #9c9c9c;
 }
  .toc .children li a:hover h5 {
@@ -983,11 +964,9 @@
      color: #6f6f6f;
 }
  .toc-full h2 {
-     font-size: 1.5625rem;
      margin: 0;
 }
  .toc-full h5 {
-     font-size: 1rem;
      text-transform: none;
      font-weight: 300;
      font-style: italic;
@@ -1011,14 +990,13 @@
  .toc-full .children .children a {
      font-family: "proxima-nova", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
      color: #6f6f6f;
-     font-size: 1rem;
      line-height: 1;
 }
  .toc-full .children .children a:hover {
      color: #8e44ad;
 }
  .toc-full .children .children .children a {
-     font-size: 0.75rem;
+     font-size: 80%;
      text-transform: uppercase;
 }
  .toc-full a {
@@ -1053,14 +1031,12 @@
      padding: 0.3rem 0;
      font-family: "proxima-nova", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
      color: #444444;
-     font-size: 1rem;
      line-height: 1;
 }
  .index-toc ul li a:hover {
      color: #8e44ad;
 }
  .index-toc h4 {
-     font-size: 1rem;
      color: #6f6f6f;
      margin: 0 0 0.625rem;
 }
@@ -1083,11 +1059,10 @@
      padding-left: 1.6875rem;
 }
  .author .author-meta h4 {
-     font-size: 1.2rem;
      margin: 0 0 0.625rem;
 }
  .author .author-meta p {
-     font-size: 0.875rem;
+     font-size: 80%;
 }
  .author .author-meta p a {
      font-family: "proxima-nova", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
@@ -1098,12 +1073,6 @@
          padding-right: 1.6875rem;
          width: 33.33333%;
          float: left;
-    }
-     .author .author-meta h4 {
-         font-size: 1.2rem;
-    }
-     .author .author-meta p {
-         font-size: 1rem;
     }
 }
  .extras {
@@ -1152,16 +1121,17 @@
  .question {
      font-family: "proxima-nova", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
      font-weight: 300;
-     font-size: 1.5625rem;
+     font-size: 1.5rem;
      line-height: 1.25;
 }
  .question:nth-child(n+2) {
      border-top: 1px solid #dddddd;
-     padding-top: 3.375rem;
-     margin-top: 3.375rem;
+     padding-top: 1em;
+     margin-top: 0;
 }
  .scroll-nav {
      margin-bottom: 3.375rem;
+     margin-left: 10%;
 }
  .scroll-nav .scroll-nav__wrapper {
      width: 100%;
@@ -1211,12 +1181,13 @@
 }
  .scroll-nav .scroll-nav__wrapper .scroll-nav__sub-list .scroll-nav__sub-item .scroll-nav__sub-link {
      display: block;
-     font-size: 0.875em;
+     font-size: 80%;
      font-family: "proxima-nova", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
-     padding: 0.4375rem 1rem;
+     padding-left: 1em;
+     padding-top: 0.5em;
+     padding-bottom: 0.5em;
      line-height: 1.2;
      color: dimgray;
-     font-style: italic;
      transition: color 0.2s;
 }
  .scroll-nav .scroll-nav__wrapper .scroll-nav__sub-list .scroll-nav__sub-item .scroll-nav__sub-link:hover {
@@ -1232,15 +1203,8 @@
      margin-top: 1.75rem;
 }
  section > h1 {
-     font-size: 3.8147rem;
      border-bottom: 2px solid #222222;
-     padding-bottom: 1rem;
-}
- @media only screen and (max-width: 40em) {
-     section > h1,
-     section > h2 {
-         font-size: 1.86157rem;
-    }
+     padding-bottom: 0.3em;
 }
  section a:hover {
      text-shadow: 0 2px white, -2px 2px white, 2px 2px white;
@@ -1254,8 +1218,8 @@
 }
  section section {
      margin-top: 2.53125rem;
-     padding-top: 2.53125rem;
-     border-top: 1px solid #dddddd;
+     padding-top: 0;
+     border-top: 0;
 }
  section h2 + section {
      margin-top: 1.6875rem;
@@ -1278,16 +1242,9 @@
      border-radius: 3px;
      margin-bottom: 1.6875rem;
      padding: 1.6875rem;
+     padding-top: 0;
 }
- section div[data-type=note] h1,
- section div[data-type=note] h2,
- section div[data-type=warning] h1,
- section div[data-type=warning] h2 {
-     font-size: 1.5625rem;
- }
- section div[data-type=note] p,
- section div[data-type=warning] p {
-     font-size: 0.875rem;
+ section div[data-type=note] p {
      font-family: "proxima-nova", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
      font-weight: normal;
 }
@@ -1303,7 +1260,7 @@
      padding: 0 1.6875rem;
 }
 
- section[data-type=chapter] aside {
+ section aside {
      margin-left: -1.6875rem;
      margin-right: -1.6875rem;
      margin-bottom: 1.6875rem;
@@ -1314,16 +1271,15 @@
      margin-top: 0;
 }
  section aside p {
-     font-size: 0.875rem;
      font-family: "proxima-nova", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
      font-weight: normal;
 }
- section aside pre, section aside div.highlight {
-     font-size: 0.875rem;
+ section aside pre, section[data-type=chapter] aside div.highlight {
+     font-size: 80%;
      background: transparent;
 }
  section div.highlight {
-     font-size: 90%;
+     font-size: 80%;
      margin-bottom: 1em;
 }
  section dl dt {
@@ -1369,7 +1325,6 @@
      text-align: left;
      border-bottom: 1px solid #dddddd;
      font-family: "proxima-nova", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
-     font-size: 1.3rem;
 }
  section table tr:nth-child(even) td {
      background: #fafafa;
@@ -1377,7 +1332,7 @@
  @media only screen and (min-width: 40.063em) {
      section section[data-type=sect1] {
          margin-top: 1.375rem;
-         padding-top: 1.375rem;
+         padding-top: 0;
     }
      section aside pre {
          margin-left: 0;
@@ -1439,7 +1394,7 @@
      max-width: 573.75rem;
      background: #ecf0f1;
      padding: 1.6875rem 0;
-     font-size: 0.875rem;
+     font-size: 80%;
 }
  footer:before, footer:after {
      content: " ";
@@ -1459,7 +1414,6 @@
      list-style: none;
      padding: 0;
      margin: 0;
-     font-size: 0.875rem;
 }
  footer ul li {
      display: inline-block;
@@ -1475,7 +1429,7 @@
      border-bottom: 1px dotted #7a3a95;
 }
  footer p {
-     font-size: 0.875rem;
+     font-size: 80%;
      margin-top: 0.5rem;
      color: #6f6f6f;
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1248,15 +1248,7 @@ h6 {
      font-family: "proxima-nova", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
      font-weight: normal;
 }
-
- section div[data-type=note] pre,
- section div[data-type=note] div.highlight,
- section div[data-type=warning] pre,
- section div[data-type=warning] div.highlight {
-     background: transparent;
-}
- section div.highlight,
- section div.highlight {
+ section div[data-type=note] div.highlight {
      padding: 0 1.6875rem;
 }
 
@@ -1273,10 +1265,6 @@ h6 {
  section aside p {
      font-family: "proxima-nova", "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
      font-weight: normal;
-}
- section aside pre, section[data-type=chapter] aside div.highlight {
-     font-size: 80%;
-     background: transparent;
 }
  section div.highlight {
      font-size: 80%;


### PR DESCRIPTION
I have trying to reduce a bit the empty spaces in the current style and to reduce the visual noise of having so many different font sizes. It's not perfect, but I feel it's a bit better compared to what it was before. There are still two many different fonts, size, and noise to my taste, but the current CSS is complex enough and my time is limited ...

Before:

<img width="1280" alt="screen shot 2018-06-01 at 18 48 17" src="https://user-images.githubusercontent.com/103693/40852950-8f542aee-65cc-11e8-892a-4eb375adcff3.png">

After:

<img width="1280" alt="screen shot 2018-06-01 at 18 48 23" src="https://user-images.githubusercontent.com/103693/40852957-95675690-65cc-11e8-8aed-cdc8cf2efb95.png">

On the variant chapter (where there are subsections):

Before:

<img width="1279" alt="screen shot 2018-06-01 at 18 50 59" src="https://user-images.githubusercontent.com/103693/40853033-e8dd3e2a-65cc-11e8-8248-fe87f4612681.png">

After:

<img width="1280" alt="screen shot 2018-06-01 at 18 51 03" src="https://user-images.githubusercontent.com/103693/40853039-ed0f170c-65cc-11e8-8b38-1afd700afe45.png">
