### PR TITLE
[Variables and Functions] replace List.dedup with List.dedup_and_sort

### DIFF
--- a/book/variables-and-functions.md
+++ b/book/variables-and-functions.md
@@ -519,7 +519,7 @@ see what happens if we try using a right-associative operator, like (^>).
 
 The type error is a little bewildering at first glance. What's going on is
 that, because `^>` is right associative, the operator is trying to feed the
-value `List.dedup ~compare:String.compare` to the function
+value `List.dedup_and_sort ~compare:String.compare` to the function
 `List.iter ~f:print_endline`. But `List.iter ~f:print_endline` expects a list
 of strings as its input, not a function.
 


### PR DESCRIPTION
This is in the section on left-associativity of `|>`. The code snippet above refers to `List.dedup_and_sort` but the text calls it as `List.dedup`.