### PR TITLE
Fixing polymorphic `>`example in variants.md

### DIFF
--- a/book/variants.md
+++ b/book/variants.md
@@ -423,8 +423,8 @@ The type system will complain if it sees incompatible uses of the same tag:
 
 The `>` at the beginning of the variant types above is critical because it
 marks the types as being open to combination with other variant types. We can
-read the type `` [> `Int of string | `Float of float]`` as describing a
-variant whose tags include `` `Int of string`` and `` `Float of float``, but
+read the type `` [> `Float of float | `Int of int]`` as describing a
+variant whose tags include `` ``Float of float`` and `` `Int of int``, but
 may include more tags as well. In other words, you can roughly translate
 `>` to mean: "these tags or more."
 


### PR DESCRIPTION
In paragraph describing use of the `>` in polymorphic types, the example I think should cite ``[> `Float of float | `Int of int]`` not ``[> `Int of string | `Float of float]``.