### PR TITLE
Make native executable extension consistent

### DIFF
--- a/book/guided-tour.md
+++ b/book/guided-tour.md
@@ -944,7 +944,7 @@ The `.exe` suffix indicates that we're building a native-code executable,
 which we'll discuss more in
 [Files Modules And Programs](files-modules-and-programs.html#files-modules-and-programs){data-type=xref}.
 Once the build completes, we can use the resulting program like any
-command-line utility. We can feed input to `sum.native` by typing in a
+command-line utility. We can feed input to `sum.exe` by typing in a
 sequence of numbers, one per line, hitting **`Ctrl-D`** when we're done:
 
 <link rel="import" href="code/guided-tour/sum/sum.rawsh" />


### PR DESCRIPTION
:wave: Thanks for working on this in the open! I'm just starting to learn, and it's been a great resource.

Line 943 calls the native executable `sum.exe`, while 947 calls it `sum.native`, so I updated the latter to make them consistent.