### PR TITLE
Fix typo in md5.ml, missing left parentheses

### DIFF
--- a/examples/code/command-line-parsing/md5_succinct/md5.ml
+++ b/examples/code/command-line-parsing/md5_succinct/md5.ml
@@ -12,7 +12,7 @@ let command =
   Command.basic
     ~summary:"Generate an MD5 hash of the input data"
     ~readme:(fun () -> "More detailed information")
-    Command.Param.(
+    (Command.Param.(
      map (anon ("filename" %: string))
        ~f:(fun filename -> (fun () -> do_hash filename))))
 


### PR DESCRIPTION
utop # let command =
  Command.basic
    ~summary:"Generate an MD5 hash of the input data"
    ~readme:(fun () -> "More detailed information")
    Command.Param.(
     map (anon ("filename" %: string))
       ~f:(fun filename -> (fun () -> do_hash filename))))
;;
Error: Syntax error

utop # let command =
  Command.basic
    ~summary:"Generate an MD5 hash of the input data"
    ~readme:(fun () -> "More detailed information")
    (Command.Param.(
     map (anon ("filename" %: string))
       ~f:(fun filename -> (fun () -> do_hash filename))))
;;

val command : Command.t = <abstr>