### PR TITLE
Fix md5.ml - use expected version of do_hash

### DIFF
--- a/examples/code/command-line-parsing/md5_as_filename/md5.ml
+++ b/examples/code/command-line-parsing/md5_as_filename/md5.ml
@@ -1,10 +1,11 @@
 open Core
 
-let do_hash file =
-  In_channel.with_file file ~f:(fun ic ->
+let do_hash hash_length filename =
+  In_channel.with_file filename ~f:(fun ic ->
     let open Cryptokit in
     hash_channel (Hash.md5 ()) ic
     |> transform_string (Hexa.encode ())
+    |> (fun s -> String.prefix s hash_length)
     |> print_endline
   )
 
@@ -14,8 +15,11 @@ let command =
     ~summary:"Generate an MD5 hash of the input data"
     ~readme:(fun () -> "More detailed information")
     Command.Let_syntax.(
-      let%map_open file = anon ("filename" %: file) in
-      fun () -> do_hash file)
+      let%map_open
+        hash_length = anon ("hash_length" %: int)
+      and filename  = anon ("filename" %: file)
+      in
+      fun () -> do_hash hash_length filename)
 
 [@@@part "2"];;
 


### PR DESCRIPTION
When reaching the "Argument Types" section in the book,
the declared version of "do_hash" takes two arguments (hash_length and filename),
so the "do_hash file" doesn't work and gives error:
Error: This expression has type string but an expression was expected of type
         int

Fix by basing the code example on the latest definition of "command".