### PR TITLE
Fix int_interval.ml, missing module ... end

### DIFF
--- a/examples/code/sexpr/test_interval/int_interval.ml
+++ b/examples/code/sexpr/test_interval/int_interval.ml
@@ -1,24 +1,28 @@
 (* Module for representing closed integer intervals *)
 open Core
 
-(* Invariant: For any Range (x,y), y >= x *)
-type t =
-  | Range of int * int
-  | Empty
-[@@deriving sexp]
+module Int_interval = struct
 
-let is_empty =
-  function
-  | Empty -> true
-  | Range _ -> false
+  (* Invariant: For any Range (x,y), y >= x *)
+  type t =
+    | Range of int * int
+    | Empty
+  [@@deriving sexp]
 
-let create x y =
-  if x > y then
-    Empty
-  else
-    Range (x,y)
+  let is_empty =
+    function
+    | Empty -> true
+    | Range _ -> false
 
-let contains i x =
-  match i with
-  | Empty -> false
-  | Range (low,high) -> x >= low && x <= high
+  let create x y =
+    if x > y then
+      Empty
+    else
+      Range (x,y)
+
+  let contains i x =
+    match i with
+    | Empty -> false
+    | Range (low,high) -> x >= low && x <= high
+
+end


### PR DESCRIPTION
Without this, the code example in test_interval.ml fails with "Error: Unbound module Int_interval".