### PR TITLE
Fix run_search_with_timeout_no_leak.sh

### DIFF
--- a/examples/code/async/search_with_timeout_no_leak/run_search_with_timeout_no_leak.sh
+++ b/examples/code/async/search_with_timeout_no_leak/run_search_with_timeout_no_leak.sh
@@ -4,14 +4,7 @@
   concurrent programming
   ----------------------
 
-  "Concurrent computing is a form of computing in which several
-  computations are executed during overlapping time
-  periods—concurrently—instead of sequentially. This is a property
-  of a system—this may be an individual program, a computer, or a
-  network—and there is a separate execution point or \"thread of
-  control\" for each computation. A concurrent system is one where a
-  computation can advance without waiting for all other computations to
-  complete."
+  DuckDuckGo query failed: Timed out
 
   ocaml
   -----


### PR DESCRIPTION
This is the corresponding text in the book:

"Now, if we run this with a suitably small timeout,
we'll see that one query succeeds and the other fails reporting a timeout:"

So one of the queries should timeout.