### PR TITLE
Change overflow-y on the navigation column to be auto instead of scroll

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -718,7 +718,7 @@ h6 {
  .left-column {
      position: absolute;
      padding-bottom: 6.75rem;
-     overflow-y: scroll;
+     overflow-y: auto;
      font-weight: normal;
 }
  .left-column.top {


### PR DESCRIPTION
When there isn't enough screen real-estate to see the whole navbar at once, a scroll-bar will pop up.  But until then, the scroll-bar is hidden.

# before 
![image](https://user-images.githubusercontent.com/573215/46700254-4bd77f80-cbea-11e8-8389-11ddf73d5c68.png)

# after
![image](https://user-images.githubusercontent.com/573215/46700274-601b7c80-cbea-11e8-9ed4-bdd4b013d7ba.png)
