### PR TITLE
files-modules-and-programs: List.sort ~cmp should be ~compare

### DIFF
--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -451,7 +451,7 @@ type median = | Median of string
 let median t =
   let sorted_strings = 
     List.sort (Map.to_alist t)
-      ~cmp:(fun (_,x) (_,y) -> Int.descending x y)
+      ~compare:(fun (_,x) (_,y) -> Int.descending x y)
   in
   let len = List.length sorted_strings in
   if len = 0 then failwith "median: empty frequency count";

--- a/examples/code/files-modules-and-programs/freq-median/counter.ml
+++ b/examples/code/files-modules-and-programs/freq-median/counter.ml
@@ -20,7 +20,7 @@ type median = | Median of string
 let median t =
   let sorted_strings = 
     List.sort (Map.to_alist t)
-      ~cmp:(fun (_,x) (_,y) -> Int.descending x y)
+      ~compare:(fun (_,x) (_,y) -> Int.descending x y)
   in
   let len = List.length sorted_strings in
   if len = 0 then failwith "median: empty frequency count";


### PR DESCRIPTION
> For example, imagine we wanted to add a function to `Counter` for returning
> the line with the median frequency count. If the number of lines is even,
> then there is no precise median, and the function would return the lines
> before and after the median instead. We'll use a custom type to represent the
> fact that there are two possible return values. Here's a possible
> implementation:
> 
> ```ocaml file=../../examples/code/files-modules-and-programs/freq-median/counter.ml,part=1
> type median = | Median of string
>               | Before_and_after of string * string
> 
> let median t =
>   let sorted_strings = 
>     List.sort (Map.to_alist t)
>       ~cmp:(fun (_,x) (_,y) -> Int.descending x y)
>   in
>   let len = List.length sorted_strings in
>   if len = 0 then failwith "median: empty frequency count";
>   let nth n = fst (List.nth_exn sorted_strings n) in
>   if len % 2 = 1
>   then Median (nth (len/2))
>   else Before_and_after (nth (len/2 - 1), nth (len/2))
> ```

The `~cmp` argument needs to be changed to `~compare` to work with Core v0.11