### PR TITLE
"String.uppercase" --> "String.uppercase_ascii"

### DIFF
--- a/book/concurrent-programming/README.md
+++ b/book/concurrent-programming/README.md
@@ -134,7 +134,7 @@ uppercase version of its contents.
 # let uppercase_file filename =
     Deferred.bind (Reader.file_contents filename)
       (fun text ->
-         Writer.save filename ~contents:(String.uppercase text))
+         Writer.save filename ~contents:(String.uppercase_ascii text))
 val uppercase_file : string -> unit Deferred.t = <fun>
 # uppercase_file "test.txt"
 - : unit = ()
@@ -154,7 +154,7 @@ includes an infix operator for it: `>>=`. Using this operator, we can rewrite
 # let uppercase_file filename =
     Reader.file_contents filename
     >>= fun text ->
-    Writer.save filename ~contents:(String.uppercase text)
+    Writer.save filename ~contents:(String.uppercase_ascii text)
 val uppercase_file : string -> unit Deferred.t = <fun>
 ```
 
@@ -646,7 +646,7 @@ let run ~uppercase ~port =
       (Tcp.Where_to_listen.of_port port)
       (fun _addr r w ->
         Pipe.transfer (Reader.pipe r) (Writer.pipe w)
-           ~f:(if uppercase then String.uppercase else Fn.id))
+           ~f:(if uppercase then String.uppercase_ascii else Fn.id))
   in
   ignore (host_and_port : (Socket.Address.Inet.t, int) Tcp.Server.t Deferred.t);
   Deferred.never ()


### PR DESCRIPTION
String.uppercase has been deprecated. Replacing "String.uppercase" with "String.uppercase_ascii" in Deferred.bind example early in README.md of "Concurrent Programming with Async" chapter that introduces >>= use, as well as two other examples further down.