### PR TITLE
Using orignal polymorphic compare operators

### DIFF
--- a/examples/code/imperative-programming/dictionary.ml
+++ b/examples/code/imperative-programming/dictionary.ml
@@ -21,10 +21,9 @@ let create () =
 
 let length t = t.length
 
-let find t key =
+let find t key ~equal =
   List.find_map t.buckets.(hash_bucket key)
-    ~f:(fun (key',data) -> if Caml.(key' = key) then Some data else None)
-
+    ~f:(fun (key', data) -> if (equal key' key) then Some data else None)
 
 [@@@part "3"];;
 let iter t ~f =
@@ -34,15 +33,15 @@ let iter t ~f =
 
 
 [@@@part "4"];;
-let bucket_has_key t i key =
-  List.exists t.buckets.(i) ~f:(fun (key',_) -> Caml.(key' = key))
+let bucket_has_key t i key ~equal =
+  List.exists t.buckets.(i) ~f:(fun (key',_) -> equal key' key)
 
-let add t ~key ~data =
+let add t ~key ~data ~equal =
   let i = hash_bucket key in
-  let replace = bucket_has_key t i key in
+  let replace = bucket_has_key t i key ~equal:equal in
   let filtered_bucket =
     if replace then
-      List.filter t.buckets.(i) ~f:(fun (key',_) -> Caml.(key' <> key))
+      List.filter t.buckets.(i) ~f:(fun (key',_) -> not (equal key' key))
     else
       t.buckets.(i)
   in
@@ -51,9 +50,9 @@ let add t ~key ~data =
 
 let remove t key =
   let i = hash_bucket key in
-  if bucket_has_key t i key then (
+  if bucket_has_key t i key ~equal then (
     let filtered_bucket =
-      List.filter t.buckets.(i) ~f:(fun (key',_) -> Caml.(key' <> key))
+      List.filter t.buckets.(i) ~f:(fun (key',_) -> not (equal key' key))
     in
     t.buckets.(i) <- filtered_bucket;
     t.length <- t.length - 1

--- a/examples/code/imperative-programming/dictionary.ml
+++ b/examples/code/imperative-programming/dictionary.ml
@@ -23,7 +23,7 @@ let length t = t.length
 
 let find t key =
   List.find_map t.buckets.(hash_bucket key)
-    ~f:(fun (key',data) -> if key' = key then Some data else None)
+    ~f:(fun (key',data) -> if Caml.(key' = key) then Some data else None)
 
 
 [@@@part "3"];;
@@ -35,14 +35,14 @@ let iter t ~f =
 
 [@@@part "4"];;
 let bucket_has_key t i key =
-  List.exists t.buckets.(i) ~f:(fun (key',_) -> key' = key)
+  List.exists t.buckets.(i) ~f:(fun (key',_) -> Caml.(key' = key))
 
 let add t ~key ~data =
   let i = hash_bucket key in
   let replace = bucket_has_key t i key in
   let filtered_bucket =
     if replace then
-      List.filter t.buckets.(i) ~f:(fun (key',_) -> key' <> key)
+      List.filter t.buckets.(i) ~f:(fun (key',_) -> Caml.(key' <> key))
     else
       t.buckets.(i)
   in
@@ -53,7 +53,7 @@ let remove t key =
   let i = hash_bucket key in
   if bucket_has_key t i key then (
     let filtered_bucket =
-      List.filter t.buckets.(i) ~f:(fun (key',_) -> key' <> key)
+      List.filter t.buckets.(i) ~f:(fun (key',_) -> Caml.(key' <> key))
     in
     t.buckets.(i) <- filtered_bucket;
     t.length <- t.length - 1

--- a/examples/code/imperative-programming/dictionary.mli
+++ b/examples/code/imperative-programming/dictionary.mli
@@ -9,6 +9,6 @@ type ('a, 'b) t
 val create : unit -> ('a, 'b) t
 val length : ('a, 'b) t -> int
 val add    : ('a, 'b) t -> key:'a -> data:'b -> unit
-val find   : ('a, 'b) t -> 'a -> 'b option
+val find   : ('a, 'b) t -> equal:('a -> 'a -> bool) -> 'a -> 'b option
 val iter   : ('a, 'b) t -> f:(key:'a -> data:'b -> unit) -> unit
 val remove : ('a, 'b) t -> 'a -> unit


### PR DESCRIPTION
Using orignal polymorphic compare operators in Caml instead of integer compare operators in Base.

Function `find`'s interface is defined as polymorphic in `.mli`.
```ocaml
val find   : ('a, 'b) t -> 'a -> 'b option
```

But `find`'s implement in `.ml` is inferred to `val find : (int, 'a) t -> int -> 'a option`
```ocaml
open Base

let find t key =
  List.find_map t.buckets.(hash_bucket key)
    ~f:(fun (key',data) -> if key' = key then Some data else None)
```

Because the type of the equality operator that’s open in Base is `int -> int -> bool` . So I use the original polymorphic operator in such way:

```ocaml
open Base

let find t key =
  List.find_map t.buckets.(hash_bucket key)
    ~f:(fun (key',data) -> if Caml.(key' = key) then Some data else None)
```

