### PR TITLE
Update link to examples

### DIFF
--- a/book/prologue/README.md
+++ b/book/prologue/README.md
@@ -259,7 +259,7 @@ snippets as you see fit in your own code, without any attribution or other
 restrictions on their use.[OCaml/code examples for]{.idx}
 
 The code repository is available online at
-[<em class="hyperlink">https://github.com/realworldocaml/examples</em>](https://github.com/realworldocaml/examples).
+[<em class="hyperlink">https://github.com/realworldocaml/book/tree/master/examples</em>](https://github.com/realworldocaml/book/tree/master/examples).
 Every code snippet in the book has a clickable header that tells you the
 filename in that repository to find the source code, shell script, or
 ancillary data file that the snippet was sourced from.


### PR DESCRIPTION
Update the examples link to point to https://github.com/realworldocaml/book/tree/master/examples.

I'm not sure if there is a long terms permalink strategy, and also if the paragraph text will need to be updated, the current version of the code snippets don't have any clickable header links.