### PR TITLE
Fix incorrect link to OCaml manual for runtime - closes #3072

### DIFF
--- a/book/garbage-collector/README.md
+++ b/book/garbage-collector/README.md
@@ -79,7 +79,7 @@ You can also control the behavior of OCaml programs by setting the
 lets you set GC parameters without recompiling, for example to benchmark the
 effects of different settings. The format of `OCAMLRUNPARAM` is documented in
 the
-[ OCaml manual](http://caml.inria.fr/pub/docs/manual-ocaml/manual024.html).
+[ OCaml manual](https://caml.inria.fr/pub/docs/manual-ocaml/runtime.html).
 
 </aside>
 


### PR DESCRIPTION
To address https://github.com/realworldocaml/book/issues/3072