### PR TITLE
Fix syntax highlight in Modules section

### DIFF
--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -265,6 +265,7 @@ The resulting code can still be built with `dune`, which will discover
 dependencies and realize that `counter.ml` needs to be compiled.
 
 ```sh dir=../../examples/code/files-modules-and-programs/freq-with-counter
+$ dune build freq.bc
 ```
 
 ## Signatures and Abstract Types
@@ -397,6 +398,7 @@ let () =
 With this implementation, the build now succeeds!
 
 ```sh dir=../../examples/code/files-modules-and-programs/freq-with-sig-abstract-fixed
+$ dune build freq.bc
 ```
 
 Now we can turn to optimizing the implementation of `Counter`. Here's an


### PR DESCRIPTION
Because empty code blocks breaks Markdown renders.
Before it was looking like this:
![image](https://user-images.githubusercontent.com/203261/58533343-cb1dd000-821a-11e9-88c0-b3478b6d5ff0.png)
