### PR TITLE
Upgrade to mdx >= 1.3.0

### DIFF
--- a/book/classes/dune.inc
+++ b/book/classes/dune.inc
@@ -8,7 +8,7 @@
          (source_tree ../../examples/code/classes-async/shapes)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y3} %{y3}.corrected)
            (diff? %{y2} %{y2}.corrected)

--- a/book/command-line-parsing/dune.inc
+++ b/book/command-line-parsing/dune.inc
@@ -30,7 +30,7 @@
          (source_tree ../../examples/code/command-line-parsing/md5_with_optional_file_broken)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y15} %{y15}.corrected)
            (diff? %{y14} %{y14}.corrected)
@@ -80,7 +80,7 @@
          (source_tree ../../examples/code/command-line-parsing/md5_with_optional_file_broken)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y15} %{y15}.corrected)
            (diff? %{y14} %{y14}.corrected)

--- a/book/compiler-backend/dune.inc
+++ b/book/compiler-backend/dune.inc
@@ -18,7 +18,7 @@
          (source_tree ../../examples/code/back-end/bench_poly_and_mono)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y9} %{y9}.corrected)
            (diff? %{y8} %{y8}.corrected)
@@ -50,7 +50,7 @@
          (source_tree ../../examples/code/back-end/bench_poly_and_mono)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y9} %{y9}.corrected)
            (diff? %{y8} %{y8}.corrected)

--- a/book/compiler-frontend/dune.inc
+++ b/book/compiler-frontend/dune.inc
@@ -22,7 +22,7 @@
          (source_tree ../../examples/code/packing)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y14} %{y14}.corrected)
            (diff? %{y13} %{y13}.corrected)
@@ -63,7 +63,7 @@
          (source_tree ../../examples/code/packing)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y14} %{y14}.corrected)
            (diff? %{y13} %{y13}.corrected)

--- a/book/concurrent-programming/dune.inc
+++ b/book/concurrent-programming/dune.inc
@@ -17,7 +17,7 @@
          (source_tree ../../examples/code/async/search_with_timeout_no_leak)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
@@ -47,7 +47,7 @@
          (source_tree ../../examples/code/async/search_with_timeout_no_leak)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)

--- a/book/data-serialization/dune.inc
+++ b/book/data-serialization/dune.inc
@@ -17,7 +17,7 @@
          (source_tree ../../examples/code/sexpr/test_interval_nosexp)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
@@ -47,7 +47,7 @@
          (source_tree ../../examples/code/sexpr/test_interval_nosexp)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)

--- a/book/error-handling/dune.inc
+++ b/book/error-handling/dune.inc
@@ -8,7 +8,7 @@
          (source_tree ../../examples/code/error-handling/exn_cost)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)
@@ -23,7 +23,7 @@
          (source_tree ../../examples/code/error-handling/exn_cost)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)

--- a/book/files-modules-and-programs/dune.inc
+++ b/book/files-modules-and-programs/dune.inc
@@ -36,7 +36,7 @@
          (source_tree ../../examples/code/files-modules-and-programs/session_info)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y21} %{y21}.corrected)
            (diff? %{y20} %{y20}.corrected)
@@ -98,7 +98,7 @@
          (source_tree ../../examples/code/files-modules-and-programs/session_info)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y21} %{y21}.corrected)
            (diff? %{y20} %{y20}.corrected)

--- a/book/first-class-modules/dune.inc
+++ b/book/first-class-modules/dune.inc
@@ -7,7 +7,7 @@
          (source_tree ../../examples/code/fcm/query_handler_loader)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)
@@ -21,7 +21,7 @@
          (source_tree ../../examples/code/fcm/query_handler_loader)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)

--- a/book/foreign-function-interface/dune.inc
+++ b/book/foreign-function-interface/dune.inc
@@ -16,7 +16,7 @@
          (source_tree ../../examples/code/ffi/qsort)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
@@ -45,7 +45,7 @@
          (source_tree ../../examples/code/ffi/qsort)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)

--- a/book/functors/dune.inc
+++ b/book/functors/dune.inc
@@ -10,7 +10,7 @@
          (:y0 ../../examples/code/functors/sexpable.ml)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y6} %{y6}.corrected)
            (diff? %{y5} %{y5}.corrected)

--- a/book/garbage-collector/dune.inc
+++ b/book/garbage-collector/dune.inc
@@ -7,7 +7,7 @@
          (source_tree ../../examples/code/gc/finalizer)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected))))
@@ -20,7 +20,7 @@
          (source_tree ../../examples/code/gc/finalizer)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected))))

--- a/book/guided-tour/dune.inc
+++ b/book/guided-tour/dune.inc
@@ -6,7 +6,7 @@
          (source_tree ../../examples/code/guided-tour/sum)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected))))

--- a/book/imperative-programming/dune.inc
+++ b/book/imperative-programming/dune.inc
@@ -15,7 +15,7 @@
          memo.ml
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --prelude=memo:memo.ml --prelude=fib:fib.ml --prelude=letrec:letrec.ml --prelude=value_restriction:letrec.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --prelude=memo:memo.ml --prelude=fib:fib.ml --prelude=letrec:letrec.ml --prelude=value_restriction:letrec.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
@@ -43,7 +43,7 @@
          memo.ml
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --prelude=memo:memo.ml --prelude=fib:fib.ml --prelude=letrec:letrec.ml --prelude=value_restriction:letrec.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --prelude=memo:memo.ml --prelude=fib:fib.ml --prelude=letrec:letrec.ml --prelude=value_restriction:letrec.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)

--- a/book/json/dune.inc
+++ b/book/json/dune.inc
@@ -12,7 +12,7 @@
          (source_tree ../../examples/code/json)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --root=../../examples/code/json %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --root=../../examples/code/json %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y7} %{y7}.corrected)
            (diff? %{y6} %{y6}.corrected)
@@ -36,7 +36,7 @@
          (source_tree ../../examples/code/json)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic --root=../../examples/code/json %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic --root=../../examples/code/json %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y7} %{y7}.corrected)
            (diff? %{y6} %{y6}.corrected)

--- a/book/lists-and-patterns/dune.inc
+++ b/book/lists-and-patterns/dune.inc
@@ -3,7 +3,7 @@
  (deps   (:x README.md)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
 )))
 (alias
@@ -11,6 +11,6 @@
  (deps   (:x README.md)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
 )))

--- a/book/maps-and-hashtables/dune.inc
+++ b/book/maps-and-hashtables/dune.inc
@@ -9,7 +9,7 @@
          (source_tree ../../examples/code/maps-and-hash-tables/map_vs_hash2)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y3} %{y3}.corrected)
            (diff? %{y2} %{y2}.corrected)
@@ -26,7 +26,7 @@
          (source_tree ../../examples/code/maps-and-hash-tables/map_vs_hash2)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y3} %{y3}.corrected)
            (diff? %{y2} %{y2}.corrected)

--- a/book/objects/dune.inc
+++ b/book/objects/dune.inc
@@ -7,7 +7,7 @@
          prelude.ml
          subtyping.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --prelude=subtyping.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --prelude=subtyping.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)
@@ -21,7 +21,7 @@
          prelude.ml
          subtyping.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --prelude=subtyping.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --prelude=subtyping.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)

--- a/book/parsing-with-ocamllex-and-menhir/dune.inc
+++ b/book/parsing-with-ocamllex-and-menhir/dune.inc
@@ -11,7 +11,7 @@
          (source_tree ../../examples/code/parsing-test)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y5} %{y5}.corrected)
            (diff? %{y4} %{y4}.corrected)

--- a/book/ppx/dune.inc
+++ b/book/ppx/dune.inc
@@ -27,7 +27,7 @@
          (source_tree ../../examples/code/packing)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y19} %{y19}.corrected)
            (diff? %{y18} %{y18}.corrected)
@@ -78,7 +78,7 @@
          (source_tree ../../examples/code/packing)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y19} %{y19}.corrected)
            (diff? %{y18} %{y18}.corrected)

--- a/book/prologue/dune.inc
+++ b/book/prologue/dune.inc
@@ -2,6 +2,6 @@
  (name   runtest)
  (deps   (:x README.md))
  (action (progn
-           (run mdx test --direction=to-ml %{x})
+           (run ocaml-mdx test --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
 )))

--- a/book/records/dune.inc
+++ b/book/records/dune.inc
@@ -3,7 +3,7 @@
  (deps   (:x README.md)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
 )))
 (alias
@@ -11,6 +11,6 @@
  (deps   (:x README.md)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x})
            (diff? %{x} %{x}.corrected)
 )))

--- a/book/runtime-memory-layout/dune.inc
+++ b/book/runtime-memory-layout/dune.inc
@@ -3,6 +3,6 @@
  (deps   (:x README.md)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
 )))

--- a/book/variables-and-functions/dune.inc
+++ b/book/variables-and-functions/dune.inc
@@ -9,7 +9,7 @@
          (:y0 ../../examples/code/variables-and-functions/substring_sig2.ml)
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y5} %{y5}.corrected)
            (diff? %{y4} %{y4}.corrected)

--- a/book/variants/dune.inc
+++ b/book/variants/dune.inc
@@ -10,7 +10,7 @@
          logger.ml
          prelude.ml)
  (action (progn
-           (run mdx test --prelude=prelude.ml --prelude=catch_all:catch_all.ml --prelude=logger:logger.ml --direction=to-ml %{x})
+           (run ocaml-mdx test --prelude=prelude.ml --prelude=catch_all:catch_all.ml --prelude=logger:logger.ml --direction=to-ml %{x})
            (diff? %{x} %{x}.corrected)
            (diff? %{y3} %{y3}.corrected)
            (diff? %{y2} %{y2}.corrected)

--- a/rwo.opam
+++ b/rwo.opam
@@ -32,7 +32,7 @@ depends: [
   "ctypes-foreign"
   "textwrap"
   "uri"
-  "mdx" {>= "1.3.0"}
+  "mdx" {= "1.4.0"}
   "async_graphics"
 ]
 build: ["dune" "build"]

--- a/rwo.opam
+++ b/rwo.opam
@@ -32,7 +32,7 @@ depends: [
   "ctypes-foreign"
   "textwrap"
   "uri"
-  "mdx" {>= "1.2.0"}
+  "mdx" {>= "1.3.0"}
   "async_graphics"
 ]
 build: ["dune" "build"]


### PR DESCRIPTION
The binary name for `mdx` changed to `ocaml-mdx` in version `1.3.0`.

We either need to add an upper bound to the `mdx` dependency or to update the `mdx` actions to use the new binary name.

The latter seemed like the right thing to do!

I'm not yet very familiar with those generated `dune` files but expect for `book/ppx/dune.inc` I only trusted the generation process with those changes.

Generating `book/ppx/dune.inc` gave me a totally different file, dropping the `runtest-all` alias entirely and dropping every dependencies and diff actions, except the ones for `x`, being the `README.md` file, in the runtest alias.

I'll investigate this further but if you  have any idea where it might come from I'd gladly take it!