### PR TITLE
Update mdx to ocaml-mdx in dune files generation rules

### DIFF
--- a/book/classes/dune
+++ b/book/classes/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/command-line-parsing/dune
+++ b/book/command-line-parsing/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/compiler-backend/dune
+++ b/book/compiler-backend/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/compiler-frontend/dune
+++ b/book/compiler-frontend/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/concurrent-programming/dune
+++ b/book/concurrent-programming/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/data-serialization/dune
+++ b/book/data-serialization/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/error-handling/dune
+++ b/book/error-handling/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/files-modules-and-programs/dune
+++ b/book/files-modules-and-programs/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/first-class-modules/dune
+++ b/book/first-class-modules/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/foreign-function-interface/dune
+++ b/book/foreign-function-interface/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/functors/dune
+++ b/book/functors/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/garbage-collector/dune
+++ b/book/garbage-collector/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/guided-tour/dune
+++ b/book/guided-tour/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/imperative-programming/dune
+++ b/book/imperative-programming/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md
+  (run ocaml-mdx rule --direction=to-ml README.md
                 --prelude=prelude.ml
                 --prelude=memo:memo.ml
                 --prelude=fib:fib.ml

--- a/book/json/dune
+++ b/book/json/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md
+  (run ocaml-mdx rule --direction=to-ml README.md
                 --root ../../examples/code/json
                 --prelude=prelude.ml)))
 

--- a/book/lists-and-patterns/dune
+++ b/book/lists-and-patterns/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/maps-and-hashtables/dune
+++ b/book/maps-and-hashtables/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/objects/dune
+++ b/book/objects/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md
+  (run ocaml-mdx rule --direction=to-ml README.md
                 --prelude=prelude.ml
                 --prelude=subtyping.ml)))
 

--- a/book/parsing-with-ocamllex-and-menhir/dune
+++ b/book/parsing-with-ocamllex-and-menhir/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/ppx/dune
+++ b/book/ppx/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/prologue/dune
+++ b/book/prologue/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md)))
+  (run ocaml-mdx rule --direction=to-ml README.md)))
 
 (alias
  (name   runtest)

--- a/book/records/dune
+++ b/book/records/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/runtime-memory-layout/dune
+++ b/book/runtime-memory-layout/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/variables-and-functions/dune
+++ b/book/variables-and-functions/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
+  (run ocaml-mdx rule --direction=to-ml README.md --prelude=prelude.ml)))
 
 (alias
  (name   runtest)

--- a/book/variants/dune
+++ b/book/variants/dune
@@ -1,5 +1,5 @@
 (rule (with-stdout-to dune.gen
-  (run mdx rule README.md --direction=to-ml
+  (run ocaml-mdx rule README.md --direction=to-ml
                           --prelude=prelude.ml
                           --prelude=catch_all:catch_all.ml
                           --prelude=logger:logger.ml)))


### PR DESCRIPTION
When updating to mdx v1.4.0 I fixed the rules generated by mdx itself but not the handwritten ones so there you go!