### PR TITLE
Fix type error of the example in chapter 4

### DIFF
--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -571,7 +571,7 @@ type session_info = { user: Username.t;
                     }
 
 let sessions_have_same_user s1 s2 =
-  Hostname.(=) s1.user s2.host
+  Username.(=) s1.user s2.host
 ```
 
 The preceding code has a bug: it compares the username in one session to the

--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -584,8 +584,8 @@ $ dune build session_info.exe
       ocamlc .session_info.eobjs/session_info.{cmi,cmo,cmt} (exit 2)
 (cd _build/default && /Users/thomas/git/rwo/book/_opam/bin/ocamlc.opt -w -40 -g -bin-annot -I /Users/thomas/git/rwo/book/_opam/lib/base -I /Users/thomas/git/rwo/book/_opam/lib/base/caml -I /Users/thomas/git/rwo/book/_opam/lib/base/md5 -I /Users/thomas/git/rwo/book/_opam/lib/base/shadow_stdlib -I /Users/thomas/git/rwo/book/_opam/lib/bin_prot -I /Users/thomas/git/rwo/book/_opam/lib/bin_prot/shape -I /Users/thomas/git/rwo/book/_opam/lib/core_kernel -I /Users/thomas/git/rwo/book/_opam/lib/core_kernel/base_for_tests -I /Users/thomas/git/rwo/book/_opam/lib/fieldslib -I /Users/thomas/git/rwo/book/_opam/lib/jane-street-headers -I /Users/thomas/git/rwo/book/_opam/lib/ppx_assert/runtime-lib -I /Users/thomas/git/rwo/book/_opam/lib/ppx_bench/runtime-lib -I /Users/thomas/git/rwo/book/_opam/lib/ppx_compare/runtime-lib -I /Users/thomas/git/rwo/book/_opam/lib/ppx_expect/collector -I /Users/thomas/git/rwo/book/_opam/lib/ppx_expect/common -I /Users/thomas/git/rwo/book/_opam/lib/ppx_expect/config -I /Users/thomas/git/rwo/book/_opam/lib/ppx_hash/runtime-lib -I /Users/thomas/git/rwo/book/_opam/lib/ppx_inline_test/config -I /Users/thomas/git/rwo/book/_opam/lib/ppx_inline_test/runtime-lib -I /Users/thomas/git/rwo/book/_opam/lib/sexplib -I /Users/thomas/git/rwo/book/_opam/lib/sexplib/0 -I /Users/thomas/git/rwo/book/_opam/lib/stdio -I /Users/thomas/git/rwo/book/_opam/lib/typerep -I /Users/thomas/git/rwo/book/_opam/lib/variantslib -no-alias-deps -I .session_info.eobjs -o .session_info.eobjs/session_info.cmo -c -impl session_info.ml)
 File "session_info.ml", line 27, characters 15-22:
-Error: This expression has type Username.t
-       but an expression was expected of type Hostname.t
+Error: This expression has type Hostname.t
+       but an expression was expected of type Username.t
 [1]
 ```
 

--- a/examples/code/files-modules-and-programs/session_info/session_info.ml
+++ b/examples/code/files-modules-and-programs/session_info/session_info.ml
@@ -24,4 +24,4 @@ type session_info = { user: Username.t;
                     }
 
 let sessions_have_same_user s1 s2 =
-  Hostname.(=) s1.user s2.host
+  Username.(=) s1.user s2.host


### PR DESCRIPTION
 According to the explanation, it should be `Username` rather than `Hostname`.