### PR TITLE
Duniverse: Fix Variables and Functions chapter

### DIFF
--- a/book/variables-and-functions/README.md
+++ b/book/variables-and-functions/README.md
@@ -707,7 +707,7 @@ Error: This expression has type string list -> unit
        but an expression was expected of type
          (string list -> string list) -> 'a
        Type string list is not compatible with type
-         string list -> string list
+         string list -> string list 
 ```
 
 The type error is a little bewildering at first glance. What's going on is


### PR DESCRIPTION
Depends on #3100, I'm leaving this as draft until it's merged! Note that only the last commit is relevant to this PR.

The tests for this chapter were working but recent `mdx` versions appear to add a trailing whitespace to a toplevel code block evaluation for some reason. The issue has been reported here: https://github.com/realworldocaml/mdx/issues/146