### PR TITLE
Duniverse: Fix Files, Modules and Programs chapter

### DIFF
--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -117,7 +117,7 @@ need a somewhat more complex invocation to get them linked in: [OCaml
 toolchain/ocamlc]{.idx}[OCaml toolchain/ocamlfind]{.idx}[Base standard
 library/finding with ocamlfind]{.idx}
 
-```sh dir=../../examples/code/files-modules-and-programs/freq
+```sh dir=../../examples/code/files-modules-and-programs/freq,skip
 $ ocamlfind ocamlc -linkpkg -package base -package stdio freq.ml -o freq.byte
 ```
 

--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -364,13 +364,11 @@ If we now try to compile `freq.ml`, we'll get the following error:
 
 ```sh dir=../../examples/code/files-modules-and-programs/freq-with-sig-abstract
 $ dune build freq.bc
-      ocamlc .freq.eobjs/freq.{cmi,cmo,cmt} (exit 2)
-...
 File "freq.ml", line 5, characters 53-66:
 Error: This expression has type Counter.t -> Base.string -> Counter.t
        but an expression was expected of type
          'a list -> Base.string -> 'a list
-       Type Counter.t is not compatible with type 'a list
+       Type Counter.t is not compatible with type 'a list 
 [1]
 ```
 
@@ -853,7 +851,7 @@ get this error.
 
 ```sh dir=../../examples/code/files-modules-and-programs/freq-with-missing-def
 $ dune build counter.bc
-Don't know how to build counter.bc
+Error: Don't know how to build counter.bc
 Hint: did you mean counter.ml?
 [1]
 ```
@@ -883,16 +881,14 @@ will lead to a compilation error.
 
 ```sh dir=../../examples/code/files-modules-and-programs/freq-with-type-mismatch
 $ dune build freq.bc
-      ocamlc .freq.eobjs/counter.{cmo,cmt} (exit 2)
-...
 File "counter.ml", line 1:
 Error: The implementation counter.ml
-       does not match the interface .freq.eobjs/counter.cmi:
+       does not match the interface .freq.eobjs/byte/counter.cmi:
        Type declarations do not match:
          type median = Median of string | Before_and_after of string * string
        is not included in
          type median = Before_and_after of string * string | Median of string
-       File "counter.mli", line 20, characters 0-84: Expected declaration
+       File "counter.mli", line 21, characters 0-84: Expected declaration
        File "counter.ml", line 18, characters 0-84: Actual declaration
        Fields number 1 have different names, Median and Before_and_after.
 [1]
@@ -951,10 +947,10 @@ the cycle:
 
 ```sh dir=../../examples/code/files-modules-and-programs/freq-cyclic2
 $ dune build freq.bc
-Dependency cycle between the following files:
-    _build/default/.freq.eobjs/counter.ml.all-deps
---> _build/default/.freq.eobjs/freq.ml.all-deps
---> _build/default/.freq.eobjs/counter.ml.all-deps
+Error: Dependency cycle between the following files:
+   _build/default/.freq.eobjs/counter.ml.all-deps
+-> _build/default/.freq.eobjs/freq.ml.all-deps
+-> _build/default/.freq.eobjs/counter.ml.all-deps
 [1]
 ```
 

--- a/examples/code/files-modules-and-programs/freq-median/counter.ml
+++ b/examples/code/files-modules-and-programs/freq-median/counter.ml
@@ -13,12 +13,13 @@ let touch t s =
   in
   Map.set t ~key:s ~data:(count + 1)
 
-[@@@part "1"]
+[@@@part "1"] ;;
+
 type median = | Median of string
               | Before_and_after of string * string
 
 let median t =
-  let sorted_strings = 
+  let sorted_strings =
     List.sort (Map.to_alist t)
       ~compare:(fun (_,x) (_,y) -> Int.descending x y)
   in
@@ -28,4 +29,3 @@ let median t =
   if len % 2 = 1
   then Median (nth (len/2))
   else Before_and_after (nth (len/2 - 1), nth (len/2))
-

--- a/examples/code/files-modules-and-programs/freq-median/counter.mli
+++ b/examples/code/files-modules-and-programs/freq-median/counter.mli
@@ -14,7 +14,8 @@ val touch : t -> string -> t
     integers will be at least 1. *)
 val to_list : t -> (string * int) list
 
-[@@@part "1"]
+[@@@part "1"] ;;
+
 (** Represents the median computed from a set of strings.  In the case where
     there is an even number of choices, the one before and after the median is
     returned.  *)

--- a/examples/code/files-modules-and-programs/freq-with-counter/counter.ml
+++ b/examples/code/files-modules-and-programs/freq-with-counter/counter.ml
@@ -1,7 +1,7 @@
 open Base
 
 let touch counts line =
-  let count = 
+  let count =
     match List.Assoc.find ~equal:String.equal counts line with
     | None -> 0
     | Some x -> x

--- a/examples/code/files-modules-and-programs/freq-with-sig-abstract/counter.ml
+++ b/examples/code/files-modules-and-programs/freq-with-sig-abstract/counter.ml
@@ -7,7 +7,7 @@ let empty = []
 let to_list x = x
 
 let touch counts line =
-  let count = 
+  let count =
     match List.Assoc.find ~equal:String.equal counts line with
     | None -> 0
     | Some x -> x

--- a/examples/code/files-modules-and-programs/freq-with-sig-mismatch/counter.ml
+++ b/examples/code/files-modules-and-programs/freq-with-sig-mismatch/counter.ml
@@ -4,8 +4,6 @@ type t = (string * int) list
 
 let empty = []
 
-let to_list x = x
-
 let touch t s =
   let count =
     match Map.find t s with

--- a/examples/code/files-modules-and-programs/freq-with-sig-mismatch/counter.mli
+++ b/examples/code/files-modules-and-programs/freq-with-sig-mismatch/counter.mli
@@ -6,11 +6,9 @@ type t
 (** The empty set of frequency counts  *)
 val empty : t
 
-[@@@part "1"]
+[@@@part "1"] ;;
+
 (** Bump the frequency count for the given string. *)
 val touch : t -> string -> t
 
-[@@@part "2"]
-(** Converts the set of frequency counts to an association list.  A string shows
-    up at most once, and the counts are >= 1. *)
-val to_list : t -> (string * int) list
+[@@@part "2"] ;;

--- a/examples/code/files-modules-and-programs/freq-with-type-mismatch/counter.mli
+++ b/examples/code/files-modules-and-programs/freq-with-type-mismatch/counter.mli
@@ -13,7 +13,8 @@ val touch : t -> string -> t
     up at most once, and the counts are >= 1. *)
 val to_list : t -> (string * int) list
 
-[@@@part "1"]
+[@@@part "1"] ;;
+
 (** Represents the median computed from a set of strings.  In the case where
     there is an even number of choices, the one before and after the median is
     returned.  *)


### PR DESCRIPTION
Depends on #3100, I'm leaving this as draft until it's merged! Note that only the last two commits are relevant to this PR.

This fixes the tests in the "Files, Modules and Programs". Most of the changes were straightforward as it was just out of date error message. There's a few things worth noting though:
- There are trailing whitespaces from the new `mdx` here as well
- `mdx` now adds `;;` after the `[@@@part ...]` attributes, I'm not sure if there's a rationale behind this but I reported it here: https://github.com/realworldocaml/mdx/issues/147
- I disabled a shell snippet with an `ocamlfind` invocation. The current dune port for findlib/ocamlfind has a few issues and I don't think it builds the `ocamlfind` executable or at least doesn't do so in a `dune` friendly way. Furthermore, it is not properly installed and lacks an initial `findlib.conf`. That needs to be fixed in the dune port although a fix upstream would probably be better.