### PR TITLE
Duniverse: Fix maps and hashtables chapter

### DIFF
--- a/book/maps-and-hashtables/README.md
+++ b/book/maps-and-hashtables/README.md
@@ -219,10 +219,10 @@ Characters 18-22:
 Error: Signature mismatch:
        ...
        The value `comparator' is required but not provided
-       File "src/comparator.mli", line 21, characters 2-53:
+       File "duniverse/base/src/comparator.mli", line 21, characters 2-53:
          Expected declaration
        The type `comparator_witness' is required but not provided
-       File "src/comparator.mli", line 20, characters 2-25:
+       File "duniverse/base/src/comparator.mli", line 20, characters 2-25:
          Expected declaration
 ```
 
@@ -693,7 +693,7 @@ module/Map.to_tree]{.idx}[maps/tree structure]{.idx}
 ```ocaml env=main
 # let ord_tree = Map.Using_comparator.to_tree ord_map
 val ord_tree :
-  (string, int, String.comparator_witness) Map.Using_comparator.Tree.t =
+  (string, int, String.comparator_witness) Core_kernel.Map_intf.Tree.t =
   <abstr>
 ```
 
@@ -720,10 +720,10 @@ following example, using the wrong comparator will lead to a type error:
 # Map.Using_comparator.Tree.find ~comparator:Reverse.comparator ord_tree "snoo"
 Characters 62-70:
 Error: This expression has type
-         (string, int, String.comparator_witness) Map.Using_comparator.Tree.t
+         (string, int, String.comparator_witness) Core_kernel.Map_intf.Tree.t
        but an expression was expected of type
          (string, int, Reverse.comparator_witness)
-         Map.Using_comparator.Tree.t
+         Core_kernel.Map_intf.Tree.t
        Type String.comparator_witness is not compatible with type
          Reverse.comparator_witness 
 ```


### PR DESCRIPTION
On #3100

~~Updated the outputs to OCaml 4.08.~~
Paths in the backtraces contains the prefix `duniverse/lib_name`, is that a problem ?