### PR TITLE
Duniverse: Fix Classes chapter

### DIFF
--- a/book/classes/README.md
+++ b/book/classes/README.md
@@ -1283,7 +1283,7 @@ which will pull in all the other dependencies:
 
 
 
-```sh dir=../../examples/code/classes-async/shapes
+```sh dir=../../examples/code/classes-async/shapes,skip
 $ dune build shapes.exe
 ```
 

--- a/examples/code/classes-async/multiple_inheritance.ml
+++ b/examples/code/classes-async/multiple_inheritance.ml
@@ -1,4 +1,4 @@
-;; [@@@part "1"] ;;
+[@@@part "1"] ;;
 
 class square_outline w x y = object
   inherit square w x y

--- a/examples/code/classes-async/multiple_inheritance_wrong.ml
+++ b/examples/code/classes-async/multiple_inheritance_wrong.ml
@@ -1,4 +1,4 @@
-;; [@@@part "1"] ;;
+[@@@part "1"] ;;
 
 class square_outline w x y = object
   method draw = draw_rect x y w w

--- a/examples/code/classes-async/shapes/shapes.ml
+++ b/examples/code/classes-async/shapes/shapes.ml
@@ -4,9 +4,7 @@ open Async_graphics
 
 type drawable = < draw: unit >
 
-;;
-
-;; [@@@part "1"] ;;
+[@@@part "1"] ;;
 
 class virtual shape x y = object(self)
   method virtual private contains: int -> int -> bool
@@ -30,9 +28,7 @@ class virtual shape x y = object(self)
            f ev.mouse_x ev.mouse_y)
 end
 
-;;
-
-;; [@@@part "2"] ;;
+[@@@part "2"] ;;
 
 class square w x y = object
   inherit shape x y
@@ -62,9 +58,7 @@ class circle r x y = object
     dist <= (Float.of_int radius)
 end
 
-;;
-
-;; [@@@part "3"] ;;
+[@@@part "3"] ;;
 
 class growing_circle r x y = object(self)
   inherit circle r x y
@@ -73,9 +67,7 @@ class growing_circle r x y = object(self)
     self#on_click (fun _x _y -> radius <- radius * 2)
 end
 
-;;
-
-;; [@@@part "4"] ;;
+[@@@part "4"] ;;
 
 class virtual draggable = object(self)
   method virtual on_mousedown:
@@ -106,18 +98,14 @@ class virtual draggable = object(self)
               y <- ev.mouse_y + offset_y))
 end
 
-;;
-
-;; [@@@part "5"] ;;
+[@@@part "5"] ;;
 
 class small_square = object
   inherit square 20 40 40
   inherit draggable
 end
 
-;;
-
-;; [@@@part "6"] ;;
+[@@@part "6"] ;;
 
 class virtual animated span = object(self)
   method virtual on_click:
@@ -147,9 +135,7 @@ class virtual animated span = object(self)
     self#on_click (fun _x _y -> if not self#running then self#animate)
 end
 
-;;
-
-;; [@@@part "7"] ;;
+[@@@part "7"] ;;
 
 class my_circle = object
   inherit circle 20 50 50
@@ -157,9 +143,7 @@ class my_circle = object
   initializer updates <- [fun _ -> x <- x + 5]
 end
 
-;;
-
-;; [@@@part "8"] ;;
+[@@@part "8"] ;;
 
 class virtual linear x' y' = object
   val virtual mutable updates: (int -> unit) list
@@ -192,9 +176,7 @@ class virtual harmonic offset x' y' = object
     updates <- update :: updates
 end
 
-;;
-
-;; [@@@part "9"] ;;
+[@@@part "9"] ;;
 
 class my_square x y = object
   inherit square 40 x y
@@ -211,9 +193,7 @@ let my_circle = object
   inherit harmonic (pi /. 2.0) 0 10
 end
 
-;;
-
-;; [@@@part "10"] ;;
+[@@@part "10"] ;;
 
 let main () =
   let shapes = [

--- a/examples/code/classes-async/verbose_shapes.ml
+++ b/examples/code/classes-async/verbose_shapes.ml
@@ -1,4 +1,4 @@
-;; [@@@part "1"] ;;
+[@@@part "1"] ;;
 
 class square w x y = object(self)
   val mutable x: int = x
@@ -23,9 +23,7 @@ class square w x y = object(self)
            f ev.mouse_x ev.mouse_y)
 end
 
-;;
-
-;; [@@@part "2"] ;;
+[@@@part "2"] ;;
 
 class circle r x y = object(self)
   val mutable x: int = x


### PR DESCRIPTION
This depends on #3100, only the last two commits are relevant to this PR.

I had to disable the `dune build` shell snippet as it relies on `async_graphics` which in turn rely on `graphics` and that last one hasn't been dunified.

Rest is just some small fixes to `.ml` files.