### PR TITLE
Fixes for FFI chapter

### DIFF
--- a/book/foreign-function-interface/README.md
+++ b/book/foreign-function-interface/README.md
@@ -180,7 +180,7 @@ The module signature for `ncurses.mli` looks much like a normal OCaml
 signature. You can infer it directly from the `ncurses.ml` by running a
 special build target:
 
-```sh dir=../../examples/code/ffi/ncurses
+```sh dir=../../examples/code/ffi/ncurses,skip
 $ corebuild -pkg ctypes-foreign ncurses.inferred.mli
 $ cp _build/ncurses.inferred.mli .
 ```
@@ -1000,7 +1000,7 @@ and also build the inferred interface so we can examine it more closely:
 
 
 
-```sh dir=../../examples/code/ffi/qsort
+```sh dir=../../examples/code/ffi/qsort,skip
 $ dune build qsort.exe
 $ cat input.txt
 2

--- a/book/foreign-function-interface/README.md
+++ b/book/foreign-function-interface/README.md
@@ -239,7 +239,7 @@ OCamlfind package:
 ```scheme
 (executable
   (name      hello)
-  (libraries ctypes-foreign)
+  (libraries ctypes-foreign.threaded)
   (flags     :standard -cclib -lncurses))
 ```
 
@@ -731,7 +731,7 @@ This can be compiled and run in the usual way: [returning function]{.idx}
 ```scheme
 (executable
   (name      datetime)
-  (libraries core ctypes-foreign))
+  (libraries core ctypes-foreign.threaded))
 ```
 
 
@@ -995,7 +995,7 @@ and also build the inferred interface so we can examine it more closely:
 ```scheme
 (executable
   (name      qsort)
-  (libraries core ctypes-foreign))
+  (libraries core ctypes-foreign.threaded))
 ```
 
 

--- a/book/foreign-function-interface/prelude.ml
+++ b/book/foreign-function-interface/prelude.ml
@@ -1,7 +1,7 @@
 #require "core,core.top,ppx_jane";;
 #require "ctypes";;
 #require "ctypes.top";;
-#require "ctypes-foreign";;
+#require "ctypes-foreign.threaded";;
 
 open Base
 open Ctypes

--- a/dune-get
+++ b/dune-get
@@ -276,7 +276,7 @@
       (ref ((t v0.12.0) (commit 50c0835df2cc13ad461ce06eb76248f8d3142d17)))
       (provided_packages (((name core_bench) (version (v0.12.0))))))
      ((dir ctypes) (upstream https://github.com/avsm/ocaml-ctypes.git)
-      (ref ((t dune-port) (commit a2030b55473871b033288b43fed0ef830213e39d)))
+      (ref ((t dune-port) (commit 81bd4c5feaac62e02c71dc26395cf815315989bf)))
       (provided_packages
        (((name ctypes) (version (0.15.1+dune)))
         ((name ctypes) (version (0.15.1+dune))))))

--- a/duniverse/ctypes/src/ctypes-foreign-threaded/dune
+++ b/duniverse/ctypes/src/ctypes-foreign-threaded/dune
@@ -5,5 +5,5 @@
   (pps bisect_ppx -conditional))
  (libraries ctypes threads)
  (private_modules Ctypes_foreign_threaded_stubs)
- (implements ctypes_foreign)
+ (implements ctypes-foreign)
  (c_names foreign_threaded_stubs))

--- a/examples/code/ffi/datetime/dune
+++ b/examples/code/ffi/datetime/dune
@@ -1,3 +1,3 @@
 (executable
   (name      datetime)
-  (libraries core ctypes-foreign))
+  (libraries core ctypes-foreign.threaded))

--- a/examples/code/ffi/hello/dune
+++ b/examples/code/ffi/hello/dune
@@ -1,4 +1,4 @@
 (executable
   (name      hello)
-  (libraries ctypes-foreign)
+  (libraries ctypes-foreign.threaded)
   (flags     :standard -cclib -lncurses))

--- a/examples/code/ffi/ncurses/dune
+++ b/examples/code/ffi/ncurses/dune
@@ -1,3 +1,3 @@
 (executable
   (name      ncurses)
-  (libraries ctypes-foreign))
+  (libraries ctypes-foreign.threaded))

--- a/examples/code/ffi/qsort/dune
+++ b/examples/code/ffi/qsort/dune
@@ -1,3 +1,3 @@
 (executable
   (name      qsort)
-  (libraries core ctypes-foreign))
+  (libraries core ctypes-foreign.threaded))


### PR DESCRIPTION
This PR finishes to fix the FFI chapter:
- It disables `corebuild` shell blocks as it depends on `ocamlfind` which isn't provided in the dune port yet
- It adds explicit dependencies to `ctypes-foreign.threaded` as the dune port virtual library part needs fixing
- It updates `ctypes` in the duniverse to fix a warning from one of its dune files