### PR TITLE
Do not install menhir in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ RUN git -C /home/opam/opam-repository pull origin master && opam update -uy
 COPY Makefile /home/opam/src/.
 RUN make depext
 RUN opam install dune=1.11.1
-# until ported to duniverse, need menhir in PATH
-RUN opam install menhir
 
 #install pandoc
 WORKDIR /tmp

--- a/book/parsing-with-ocamllex-and-menhir/README.md
+++ b/book/parsing-with-ocamllex-and-menhir/README.md
@@ -728,7 +728,7 @@ null
 Now build and run the example using this file, and you can see the full
 parser in action:
 
-```sh dir=../../examples/code/parsing-test
+```sh dir=../../examples/code/parsing-test,skip
 $ dune exec ./test.exe test1.json
 true
 false
@@ -745,7 +745,7 @@ null
 With our simple error handling scheme, errors are fatal and cause the program
 to terminate with a nonzero exit code:
 
-```sh dir=../../examples/code/parsing-test
+```sh dir=../../examples/code/parsing-test,skip
 $ cat test2.json
 { "name": "Chicago",
   "zips": [12345,


### PR DESCRIPTION
Because menhir depends on ocamlfind, installing it through opam
in the CI may lead to issues where the opam ocamlfind is picked over
the duniverse one or where the two conflicts.

It's probably better to wait for a proper dune port.