### PR TITLE
Add global lock to `mdx test` rules

### DIFF
--- a/book/classes/dune
+++ b/book/classes/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/classes/dune.inc
+++ b/book/classes/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/classes/dune.inc
+++ b/book/classes/dune.inc
@@ -15,6 +15,7 @@
          (:y0 ../../examples/code/classes-async/verbose_shapes.ml)
          (source_tree ../../examples/code/classes-async/shapes)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y3} %{y3}.corrected)

--- a/book/command-line-parsing/dune
+++ b/book/command-line-parsing/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude prelude.ml))))
 
 (alias

--- a/book/command-line-parsing/dune.inc
+++ b/book/command-line-parsing/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/command-line-parsing/dune.inc
+++ b/book/command-line-parsing/dune.inc
@@ -37,6 +37,7 @@
          (source_tree ../../examples/code/command-line-parsing/md5_with_optional_file)
          (source_tree ../../examples/code/command-line-parsing/md5_with_optional_file_broken)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y15} %{y15}.corrected)
@@ -91,6 +92,7 @@
          (source_tree ../../examples/code/command-line-parsing/md5_with_optional_file)
          (source_tree ../../examples/code/command-line-parsing/md5_with_optional_file_broken)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y15} %{y15}.corrected)

--- a/book/compiler-backend/dune
+++ b/book/compiler-backend/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/compiler-backend/dune.inc
+++ b/book/compiler-backend/dune.inc
@@ -25,6 +25,7 @@
          (source_tree ../../examples/code/back-end/bench_patterns)
          (source_tree ../../examples/code/back-end/bench_poly_and_mono)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y9} %{y9}.corrected)
@@ -61,6 +62,7 @@
          (source_tree ../../examples/code/back-end/bench_patterns)
          (source_tree ../../examples/code/back-end/bench_poly_and_mono)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y9} %{y9}.corrected)

--- a/book/compiler-backend/dune.inc
+++ b/book/compiler-backend/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/compiler-frontend/dune
+++ b/book/compiler-frontend/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/compiler-frontend/dune.inc
+++ b/book/compiler-frontend/dune.inc
@@ -29,6 +29,7 @@
          (source_tree ../../examples/code/front-end)
          (source_tree ../../examples/code/packing)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y14} %{y14}.corrected)
@@ -74,6 +75,7 @@
          (source_tree ../../examples/code/front-end)
          (source_tree ../../examples/code/packing)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y14} %{y14}.corrected)

--- a/book/compiler-frontend/dune.inc
+++ b/book/compiler-frontend/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/concurrent-programming/dune
+++ b/book/concurrent-programming/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/concurrent-programming/dune.inc
+++ b/book/concurrent-programming/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/concurrent-programming/dune.inc
+++ b/book/concurrent-programming/dune.inc
@@ -28,6 +28,7 @@
          (source_tree ../../examples/code/async/search_with_error_handling)
          (source_tree ../../examples/code/async/search_with_timeout_no_leak)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y8} %{y8}.corrected)
@@ -66,6 +67,7 @@
          (source_tree ../../examples/code/async/search_with_error_handling)
          (source_tree ../../examples/code/async/search_with_timeout_no_leak)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y8} %{y8}.corrected)

--- a/book/data-serialization/dune
+++ b/book/data-serialization/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/data-serialization/dune.inc
+++ b/book/data-serialization/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/data-serialization/dune.inc
+++ b/book/data-serialization/dune.inc
@@ -24,6 +24,7 @@
          (source_tree ../../examples/code/sexpr/test_interval)
          (source_tree ../../examples/code/sexpr/test_interval_nosexp)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y8} %{y8}.corrected)
@@ -58,6 +59,7 @@
          (source_tree ../../examples/code/sexpr/test_interval)
          (source_tree ../../examples/code/sexpr/test_interval_nosexp)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y8} %{y8}.corrected)

--- a/book/error-handling/dune
+++ b/book/error-handling/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/error-handling/dune.inc
+++ b/book/error-handling/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/error-handling/dune.inc
+++ b/book/error-handling/dune.inc
@@ -15,6 +15,7 @@
          (source_tree ../../examples/code/error-handling/blow_up)
          (source_tree ../../examples/code/error-handling/exn_cost)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y2} %{y2}.corrected)
@@ -34,6 +35,7 @@
          (source_tree ../../examples/code/error-handling/blow_up)
          (source_tree ../../examples/code/error-handling/exn_cost)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y2} %{y2}.corrected)

--- a/book/files-modules-and-programs/dune
+++ b/book/files-modules-and-programs/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/files-modules-and-programs/dune.inc
+++ b/book/files-modules-and-programs/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/files-modules-and-programs/dune.inc
+++ b/book/files-modules-and-programs/dune.inc
@@ -43,6 +43,7 @@
          (source_tree ../../examples/code/files-modules-and-programs/freq-with-type-mismatch)
          (source_tree ../../examples/code/files-modules-and-programs/session_info)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y21} %{y21}.corrected)
@@ -109,6 +110,7 @@
          (source_tree ../../examples/code/files-modules-and-programs/freq-with-type-mismatch)
          (source_tree ../../examples/code/files-modules-and-programs/session_info)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y21} %{y21}.corrected)

--- a/book/first-class-modules/dune
+++ b/book/first-class-modules/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/first-class-modules/dune.inc
+++ b/book/first-class-modules/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/first-class-modules/dune.inc
+++ b/book/first-class-modules/dune.inc
@@ -14,6 +14,7 @@
          (:y0 ../../examples/code/fcm/query_handler_loader/query_handler_loader.ml)
          (source_tree ../../examples/code/fcm/query_handler_loader)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y2} %{y2}.corrected)
@@ -32,6 +33,7 @@
          (:y0 ../../examples/code/fcm/query_handler_loader/query_handler_loader.ml)
          (source_tree ../../examples/code/fcm/query_handler_loader)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y2} %{y2}.corrected)

--- a/book/foreign-function-interface/dune
+++ b/book/foreign-function-interface/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/foreign-function-interface/dune.inc
+++ b/book/foreign-function-interface/dune.inc
@@ -25,6 +25,7 @@
          (source_tree ../../examples/code/ffi/ncurses)
          (source_tree ../../examples/code/ffi/qsort)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y8} %{y8}.corrected)
@@ -60,6 +61,7 @@
          (source_tree ../../examples/code/ffi/ncurses)
          (source_tree ../../examples/code/ffi/qsort)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y8} %{y8}.corrected)

--- a/book/foreign-function-interface/dune.inc
+++ b/book/foreign-function-interface/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/functors/dune
+++ b/book/functors/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/functors/dune.inc
+++ b/book/functors/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/functors/dune.inc
+++ b/book/functors/dune.inc
@@ -17,6 +17,7 @@
          (:y1 ../../examples/code/functors/fqueue.mli)
          (:y0 ../../examples/code/functors/sexpable.ml)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y6} %{y6}.corrected)

--- a/book/garbage-collector/dune
+++ b/book/garbage-collector/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/garbage-collector/dune.inc
+++ b/book/garbage-collector/dune.inc
@@ -16,6 +16,7 @@
          (source_tree ../../examples/code/gc/barrier_bench)
          (source_tree ../../examples/code/gc/finalizer)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y1} %{y1}.corrected)
@@ -35,6 +36,7 @@
          (source_tree ../../examples/code/gc/barrier_bench)
          (source_tree ../../examples/code/gc/finalizer)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y1} %{y1}.corrected)

--- a/book/garbage-collector/dune.inc
+++ b/book/garbage-collector/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/guided-tour/dune
+++ b/book/guided-tour/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/guided-tour/dune.inc
+++ b/book/guided-tour/dune.inc
@@ -13,6 +13,7 @@
          (:y0 ../../examples/code/guided-tour/sum/sum.ml)
          (source_tree ../../examples/code/guided-tour/sum)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y1} %{y1}.corrected)

--- a/book/guided-tour/dune.inc
+++ b/book/guided-tour/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/imperative-programming/dune
+++ b/book/imperative-programming/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
                 --prelude=%{dep:prelude.ml}
                 --prelude=memo:%{dep:memo.ml}
                 --prelude=fib:%{dep:fib.ml}

--- a/book/imperative-programming/dune.inc
+++ b/book/imperative-programming/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/imperative-programming/dune.inc
+++ b/book/imperative-programming/dune.inc
@@ -22,6 +22,7 @@
          letrec.ml
          memo.ml
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=memo:memo.ml --prelude=fib:fib.ml --prelude=letrec:letrec.ml --prelude=value_restriction:letrec.ml --direction=to-ml %{x}))
            (diff? %{y8} %{y8}.corrected)
@@ -54,6 +55,7 @@
          letrec.ml
          memo.ml
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=memo:memo.ml --prelude=fib:fib.ml --prelude=letrec:letrec.ml --prelude=value_restriction:letrec.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y8} %{y8}.corrected)

--- a/book/json/dune
+++ b/book/json/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
                 --root ../../examples/code/json
                 --prelude=%{dep:prelude.ml}))))
 

--- a/book/json/dune.inc
+++ b/book/json/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/json/dune.inc
+++ b/book/json/dune.inc
@@ -20,6 +20,7 @@
          (:y0 ../../examples/code/json/yojson_safe.mli)
          (source_tree ../../examples/code/json)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --root=../../examples/code/json %{x}))
            (diff? %{y7} %{y7}.corrected)
@@ -49,6 +50,7 @@
          (:y0 ../../examples/code/json/yojson_safe.mli)
          (source_tree ../../examples/code/json)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic --root=../../examples/code/json %{x}))
            (diff? %{y7} %{y7}.corrected)

--- a/book/lists-and-patterns/dune
+++ b/book/lists-and-patterns/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/lists-and-patterns/dune.inc
+++ b/book/lists-and-patterns/dune.inc
@@ -11,6 +11,7 @@
          (package core_bench)
          (package ppx_jane)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
 
@@ -24,6 +25,7 @@
          (package core_bench)
          (package ppx_jane)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
 

--- a/book/lists-and-patterns/dune.inc
+++ b/book/lists-and-patterns/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/maps-and-hashtables/dune
+++ b/book/maps-and-hashtables/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/maps-and-hashtables/dune.inc
+++ b/book/maps-and-hashtables/dune.inc
@@ -16,6 +16,7 @@
          (source_tree ../../examples/code/maps-and-hash-tables/map_vs_hash)
          (source_tree ../../examples/code/maps-and-hash-tables/map_vs_hash2)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y3} %{y3}.corrected)
@@ -37,6 +38,7 @@
          (source_tree ../../examples/code/maps-and-hash-tables/map_vs_hash)
          (source_tree ../../examples/code/maps-and-hash-tables/map_vs_hash2)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y3} %{y3}.corrected)

--- a/book/maps-and-hashtables/dune.inc
+++ b/book/maps-and-hashtables/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/objects/dune
+++ b/book/objects/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
                 --prelude=%{dep:prelude.ml}
                 --prelude=%{dep:subtyping.ml}))))
 

--- a/book/objects/dune.inc
+++ b/book/objects/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/objects/dune.inc
+++ b/book/objects/dune.inc
@@ -14,6 +14,7 @@
          (:y0 ../../examples/code/objects/subtyping.ml)
          prelude.ml
          subtyping.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=subtyping.ml --direction=to-ml %{x}))
            (diff? %{y2} %{y2}.corrected)
@@ -32,6 +33,7 @@
          (:y0 ../../examples/code/objects/subtyping.ml)
          prelude.ml
          subtyping.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=subtyping.ml --direction=to-ml --non-deterministic %{x}))
            (diff? %{y2} %{y2}.corrected)

--- a/book/parsing-with-ocamllex-and-menhir/dune
+++ b/book/parsing-with-ocamllex-and-menhir/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/parsing-with-ocamllex-and-menhir/dune.inc
+++ b/book/parsing-with-ocamllex-and-menhir/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/parsing-with-ocamllex-and-menhir/dune.inc
+++ b/book/parsing-with-ocamllex-and-menhir/dune.inc
@@ -18,6 +18,7 @@
          (source_tree ../../examples/code/parsing)
          (source_tree ../../examples/code/parsing-test)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y5} %{y5}.corrected)

--- a/book/ppx/dune
+++ b/book/ppx/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/ppx/dune.inc
+++ b/book/ppx/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/ppx/dune.inc
+++ b/book/ppx/dune.inc
@@ -10,6 +10,7 @@
          (package core)
          (package ppx_jane)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
 

--- a/book/prologue/dune
+++ b/book/prologue/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}))))
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}))))
 
 (alias
  (name   runtest)

--- a/book/prologue/dune.inc
+++ b/book/prologue/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/prologue/dune.inc
+++ b/book/prologue/dune.inc
@@ -7,6 +7,7 @@
  (deps   (:x README.md)
          (:conf findlib.conf)
          (package mdx))
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --direction=to-ml %{x}))
 

--- a/book/records/dune
+++ b/book/records/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/records/dune.inc
+++ b/book/records/dune.inc
@@ -11,6 +11,7 @@
          (package ppx_jane)
          (package re)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
 
@@ -24,6 +25,7 @@
          (package ppx_jane)
          (package re)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
 

--- a/book/records/dune.inc
+++ b/book/records/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/runtime-memory-layout/dune
+++ b/book/runtime-memory-layout/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/runtime-memory-layout/dune.inc
+++ b/book/runtime-memory-layout/dune.inc
@@ -9,6 +9,7 @@
          (package mdx)
          (package ocaml-compiler-libs)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
 

--- a/book/runtime-memory-layout/dune.inc
+++ b/book/runtime-memory-layout/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/variables-and-functions/dune
+++ b/book/variables-and-functions/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/variables-and-functions/dune.inc
+++ b/book/variables-and-functions/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/variables-and-functions/dune.inc
+++ b/book/variables-and-functions/dune.inc
@@ -16,6 +16,7 @@
          (:y1 ../../examples/code/variables-and-functions/substring_sig1.ml)
          (:y0 ../../examples/code/variables-and-functions/substring_sig2.ml)
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
            (diff? %{y5} %{y5}.corrected)

--- a/book/variants/dune
+++ b/book/variants/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
       --prelude=%{dep:prelude.ml}
       --prelude=catch_all:%{dep:catch_all.ml}
       --prelude=logger:%{dep:logger.ml}))))

--- a/book/variants/dune.inc
+++ b/book/variants/dune.inc
@@ -1,6 +1,6 @@
 (rule
  (target findlib.conf)
- (action (write-file %{target} "path=\"%{project_root}/_build/install/%{context_name}/lib\"")))
+ (action (write-file %{target} "")))
 
 (alias
  (name   runtest)

--- a/book/variants/dune.inc
+++ b/book/variants/dune.inc
@@ -17,6 +17,7 @@
          catch_all.ml
          logger.ml
          prelude.ml)
+ (locks ../../global-lock)
  (action (progn
            (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=catch_all:catch_all.ml --prelude=logger:logger.ml --direction=to-ml %{x}))
            (diff? %{y3} %{y3}.corrected)

--- a/dune-get
+++ b/dune-get
@@ -369,7 +369,7 @@
       (provided_packages (((name rresult) (version (0.6.0+dune))))))
      ((dir mdx) (upstream https://github.com/Julow/mdx.git)
       (ref
-       ((t duniverse_mode) (commit f71390f0cd4d000f0a3d364910cf8a53ed412847)))
+       ((t duniverse_mode) (commit 22380b81483bc3497b9b34c8819037505f268043)))
       (provided_packages (((name mdx) (version (1.4.0))))))
      ((dir splittable_random)
       (upstream https://github.com/janestreet/splittable_random.git)


### PR DESCRIPTION
This PR updates mdx which leads to an update of the default rules for the duniverse mode. It now only sets the inital findlib.conf as an empty file so the library successfully initialize and let `dune` set its path.

The update also include a `--locks` option that allows us to set locks for the generated rules. I used that to set a global lock, shared between each chapters so that the mdx commands aren't executed concurrently as this was leading to non deterministic failures of the tests.