### PR TITLE
Fix guided tour's prelude.ml

### DIFF
--- a/book/guided-tour/prelude.ml
+++ b/book/guided-tour/prelude.ml
@@ -1,4 +1,5 @@
-#require "base,ppx_jane";;
+#require "base";;
+#require "ppx_jane";;
 
 open Base
 


### PR DESCRIPTION
We should never use `#require "a,b";;` as that result in neither being loaded if there's an issue with one and that makes it a bit hard to debug!

`ppx_jane` is not loaded properly because `bin_prot` is not installed in `_build/install` for some reason, we can work this out later as the chapter's tests now build!