### PR TITLE
Async small fixes

### DIFF
--- a/book/concurrent-programming/README.md
+++ b/book/concurrent-programming/README.md
@@ -1390,15 +1390,18 @@ single deferred that will become determined once any of the values on the
 list is determined.
 
 ```ocaml env=main
-# Deferred.any [ (after (sec 0.5) >>| fun () -> "half a second")
-  ; (after (sec 10.) >>| fun () -> "ten seconds") ]
+# Deferred.any
+  [ (after (sec 0.5) >>| fun () -> "half a second")
+  ; (after (sec 1.0) >>| fun () -> "one second")
+  ; (after (sec 4.0) >>| fun () -> "four seconds")
+  ]
 - : string = "half a second"
 ```
 
-Let's use this to add timeouts to our DuckDuckGo searches. The following code
-is a wrapper for `get_definition` that takes a timeout (in the form of a
-`Time.Span.t`) and returns either the definition, or, if that takes too long,
-an error:
+Let's use this to add timeouts to our DuckDuckGo searches. The
+following code is a wrapper for `get_definition` that takes a timeout
+(in the form of a `Time.Span.t`) and returns either the definition,
+or, if that takes too long, an error:
 
 ```ocaml file=../../examples/code/async/search_with_timeout.ml,part=1
 let get_definition_with_timeout ~server ~timeout word =
@@ -1458,9 +1461,9 @@ let get_definition_with_timeout ~server ~timeout word =
   (word,result')
 ```
 
-This will work and will cause the connection to shutdown cleanly when we time
-out; but our code no longer explicitly knows whether or not the timeout has
-kicked in. In particular, the error message on a timeout will now be
+This will cause the connection to shutdown cleanly when we time out;
+but our code no longer explicitly knows whether or not the timeout has
+kicked in.  In particular, the error message on a timeout will now be
 `"Unexpected failure"` rather than `"Timed out"`, which it was in our
 previous implementation.
 

--- a/book/concurrent-programming/README.md
+++ b/book/concurrent-programming/README.md
@@ -44,7 +44,7 @@ of]{.idx}
 
 ## Async Basics
 
-Recall how I/O is typically done in Core. Here's a simple example:
+Recall how I/O is typically done in Core. Here's a simple example.
 
 ```ocaml env=main
 # open Core
@@ -1275,9 +1275,8 @@ In addition, we'll make the necessary changes to get the list of servers on
 the command-line, and to distribute the search queries round-robin across the
 list of servers.
 
-But first, let's see what happens if we rebuild the application and
-run it giving it a list of servers, some of which won't respond to the
-query.
+Now, let's see what happens when we rebuild the application and run it
+two servers, one of which won't respond to the query.
 
 ```sh dir=../../examples/code/async/search_with_configurable_server,non-deterministic=output
 $ dune exec -- ./search.exe -servers localhost,api.duckduckgo.com "Concurrent Programming" "OCaml"
@@ -1335,7 +1334,7 @@ Now, if we run that same query, we'll get individualized handling of the
 connection failures:
 
 ```sh dir=../../examples/code/async/search_with_error_handling,non-deterministic=output
-$ dune exec -- ./search.exe -- -servers localhost,api.duckduckgo.com "Concurrent Programming" OCaml
+$ dune exec -- ./search.exe -servers localhost,api.duckduckgo.com "Concurrent Programming" OCaml
 Concurrent Programming
 ----------------------
 


### PR DESCRIPTION
Various small improvements and cleanups to the Async chapter.  This includes making some things "notes" that were previously asides (which seem not to be supported anymore in the toolchain), and also taking the existing monitor section and just converting it to a note, on the theory that it's tricky stuff that one can skip at first.