### PR TITLE
replaced all remaining asides

### DIFF
--- a/book/compiler-backend/README.md
+++ b/book/compiler-backend/README.md
@@ -95,7 +95,7 @@ drop the number of variants to just two, then there's no need for the
 complexity of computing this table:
 
 ```ocaml file=../../examples/code/back-end/pattern_monomorphic_small.ml
-type t = | Alice | Bob 
+type t = | Alice | Bob
 
 let test v =
   match v with
@@ -249,13 +249,13 @@ default, and you'll see the results summarized in a neat table:
 $ dune build bench_patterns.exe
 $ ./_build/default/bench_patterns.exe -ascii -quota 0.25
 Estimated testing time 750ms (3 benchmarks x 250ms). Change using -quota SECS.
-                                                      
-  Name                         Time/Run   Percentage  
- ---------------------------- ---------- ------------ 
-  Polymorphic pattern           24.93ns       89.45%  
-  Monomorphic larger pattern    27.88ns      100.00%  
-  Monomorphic small pattern     10.84ns       38.90%  
-                                                      
+
+  Name                         Time/Run   Percentage
+ ---------------------------- ---------- ------------
+  Polymorphic pattern           24.93ns       89.45%
+  Monomorphic larger pattern    27.88ns      100.00%
+  Monomorphic small pattern     10.84ns       38.90%
+
 ```
 
 These results confirm the performance hypothesis that we obtained earlier by
@@ -305,8 +305,8 @@ block
 code offset
 : Values that are relative to the starting code address
 
-The interpreter virtual machine only has seven registers in total: 
-- program counter, 
+The interpreter virtual machine only has seven registers in total:
+- program counter,
 - stack, exception and argument pointers,
 - accumulator,
 - environment and global data.
@@ -475,7 +475,7 @@ Next, create a C file to be your main entry point:
 #include <caml/memory.h>
 #include <caml/callback.h>
 
-int 
+int
 main (int argc, char **argv)
 {
   printf("Before calling OCaml\n");
@@ -733,12 +733,12 @@ Running this shows quite a significant runtime difference between the two:
 $ dune build bench_poly_and_mono.exe
 $ ./_build/default/bench_poly_and_mono.exe -ascii -quota 1
 Estimated testing time 2s (2 benchmarks x 1s). Change using -quota SECS.
-                                                     
-  Name                        Time/Run   Percentage  
- ------------------------ ------------- ------------ 
-  Polymorphic comparison   18_402.43ns      100.00%  
-  Monomorphic comparison      734.22ns        3.99%  
-                                                     
+
+  Name                        Time/Run   Percentage
+ ------------------------ ------------- ------------
+  Polymorphic comparison   18_402.43ns      100.00%
+  Monomorphic comparison      734.22ns        3.99%
+
 ```
 
 We see that the polymorphic comparison is close to 20 times slower! These
@@ -881,7 +881,7 @@ The `gdb` prompt lets you enter debug directives. Let's set the program to
 break just before the first call to `take`:
 
 ```
-(gdb) break camlAlternate_list__take_69242 
+(gdb) break camlAlternate_list__take_69242
 Breakpoint 1 at 0x5658d0: file alternate_list.ml, line 5.
 ```
 
@@ -897,7 +897,7 @@ Once you've set the breakpoint, start the program executing:
 Starting program: /home/avsm/alternate_list.native
 [Thread debugging using libthread_db enabled]
 Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
- 
+
 Breakpoint 1, camlAlternate_list__take_69242 () at alternate_list.ml:5
 4         function
 ```
@@ -909,12 +909,12 @@ and check the stacktrace after a couple of recursions:
 ```
 (gdb) cont
 Continuing.
- 
+
 Breakpoint 1, camlAlternate_list__take_69242 () at alternate_list.ml:5
 4         function
 (gdb) cont
 Continuing.
- 
+
 Breakpoint 1, camlAlternate_list__take_69242 () at alternate_list.ml:5
 4         function
 (gdb) bt
@@ -927,7 +927,7 @@ Breakpoint 1, camlAlternate_list__take_69242 () at alternate_list.ml:5
 #6  0x00000000008099a0 in ?? ()
 #7  0x0000000000000000 in ?? ()
 (gdb) clear camlAlternate_list__take_69242
-Deleted breakpoint 1 
+Deleted breakpoint 1
 (gdb) cont
 Continuing.
 1,3,5,7,9
@@ -994,22 +994,22 @@ in-place modification:
 ```
 $ perf record -g ./barrier_bench.native
 Estimated testing time 20s (change using -quota SECS).
- 
+
   Name        Time (ns)             Time 95ci   Percentage
   ----        ---------             ---------   ----------
   mutable     7_306_219   7_250_234-7_372_469        96.83
   immutable   7_545_126   7_537_837-7_551_193       100.00
- 
+
 [ perf record: Woken up 11 times to write data ]
 [ perf record: Captured and wrote 2.722 MB perf.data (~118926 samples) ]
 perf record -g ./barrier.native
 Estimated testing time 20s (change using -quota SECS).
- 
+
   Name        Time (ns)             Time 95ci   Percentage
   ----        ---------             ---------   ----------
   mutable     7_306_219   7_250_234-7_372_469        96.83
   immutable   7_545_126   7_537_837-7_551_193       100.00
- 
+
 [ perf record: Woken up 11 times to write data ]
 [ perf record: Captured and wrote 2.722 MB perf.data (~118926 samples) ]
 ```
@@ -1032,8 +1032,8 @@ Perf has a growing collection of other commands that let you archive these
 runs and compare them against each other. You can read more on the
 [home page](http://perf.wiki.kernel.org). [frame pointers]{.idx}
 
-<aside data-type="sidebar">
-<h5>Using the Frame Pointer to Get More Accurate Traces</h5>
+::: {data-type=note}
+##### Using the Frame Pointer to Get More Accurate Traces
 
 Although Perf doesn't require adding in explicit probes to the binary, it
 does need to understand how to unwind function calls so that the kernel can
@@ -1062,7 +1062,7 @@ care of recompiling all your libraries with the new interface. You can read
 more about this on the OCamlPro
 [ blog](http://www.ocamlpro.com/blog/2012/08/08/profile-native-code.html).
 
-</aside>
+:::
 
 
 ### Embedding Native Code in C
@@ -1116,7 +1116,7 @@ To use the debug library, just link your program with the
 $ ocamlopt -runtime-variant d -verbose -o hello.native hello.ml
 + clang -arch x86_64 -Wno-trigraphs -c -o 'hello.o' '/var/folders/9g/7vjfw6kn7k9bs721d_zjzn7h0000gn/T/camlasm9b916c.s'
 + clang -arch x86_64 -Wno-trigraphs -c -o '/var/folders/9g/7vjfw6kn7k9bs721d_zjzn7h0000gn/T/camlstartup8f1c0d.o' '/var/folders/9g/7vjfw6kn7k9bs721d_zjzn7h0000gn/T/camlstartupf69d9a.s'
-+ cc -O2 -fno-strict-aliasing -fwrapv -Wall -D_FILE_OFFSET_BITS=64 -D_REENTRANT -DCAML_NAME_SPACE   -Wl,-no_compact_unwind -o 'hello.native'   '-L/Users/thomas/git/rwo/book/_opam/lib/ocaml'  '/var/folders/9g/7vjfw6kn7k9bs721d_zjzn7h0000gn/T/camlstartup8f1c0d.o' '/Users/thomas/git/rwo/book/_opam/lib/ocaml/std_exit.o' 'hello.o' '/Users/thomas/git/rwo/book/_opam/lib/ocaml/stdlib.a' '/Users/thomas/git/rwo/book/_opam/lib/ocaml/libasmrund.a' 
++ cc -O2 -fno-strict-aliasing -fwrapv -Wall -D_FILE_OFFSET_BITS=64 -D_REENTRANT -DCAML_NAME_SPACE   -Wl,-no_compact_unwind -o 'hello.native'   '-L/Users/thomas/git/rwo/book/_opam/lib/ocaml'  '/var/folders/9g/7vjfw6kn7k9bs721d_zjzn7h0000gn/T/camlstartup8f1c0d.o' '/Users/thomas/git/rwo/book/_opam/lib/ocaml/std_exit.o' 'hello.o' '/Users/thomas/git/rwo/book/_opam/lib/ocaml/stdlib.a' '/Users/thomas/git/rwo/book/_opam/lib/ocaml/libasmrund.a'
 $ ./hello.native
 ### OCaml runtime: debug mode ###
 Initial minor heap size: 256k words
@@ -1177,4 +1177,3 @@ Extension | Purpose
 
 Table:  Intermediate outputs produced by the native code OCaml toolchain
 :::
-

--- a/book/compiler-frontend/README.md
+++ b/book/compiler-frontend/README.md
@@ -65,8 +65,8 @@ compiler generates specialized executable binaries suitable for
 high-performance applications.[compilation process/compiler source
 code]{.idx}[code compilers/bytecode vs. native code]{.idx}
 
-<aside data-type="sidebar">
-<h5>Obtaining the Compiler Source Code</h5>
+::: {data-type=note}
+##### Obtaining the Compiler Source Code
 
 Although it's not necessary to understand the examples, you may find it
 useful to have a copy of the OCaml source tree checked out while you read
@@ -128,7 +128,7 @@ A number of tools and scripts are also built alongside the core compiler:
 `testsuite/`
 : Regression tests for the core compiler.
 
-</aside>
+:::
 
 We'll go through each of the compilation stages now and explain how they will
 be useful to you during day-to-day OCaml development.
@@ -846,8 +846,8 @@ override the default path unless you have a good reason to (such as setting
 up a cross-compilation environment). [cmi files]{.idx}[files/cmi
 files]{.idx}[OCaml toolchain/ocamlogjinfo]{.idx}
 
-<aside data-type="sidebar">
-<h5>Inspecting Compilation Units with ocamlobjinfo</h5>
+::: {data-type=note}
+##### Inspecting Compilation Units with ocamlobjinfo
 
 For separate compilation to be sound, we need to ensure that all the
 `cmi` files used to type-check a module are the same across compilation runs.
@@ -898,7 +898,7 @@ should ensure that you never see the preceding error messages, but if you do
 run into it, just clean out your intermediate files and recompile from
 scratch.
 
-</aside>
+:::
 
 
 ### Packing Modules Together

--- a/book/foreign-function-interface/README.md
+++ b/book/foreign-function-interface/README.md
@@ -744,8 +744,8 @@ $ ./_build/default/datetime.exe -a
 Tue Mar  6 13:27:51 2018
 ```
 
-<aside data-type="sidebar">
-<h5>Why Do We Need to Use returning?</h5>
+::: {data-type=note}
+##### Why Do We Need to Use returning?
 
 The alert reader may be curious about why all these function definitions have
 to be terminated by `returning`:
@@ -822,7 +822,7 @@ types are the same but the C semantics are quite different, we need some kind
 of marker to distinguish the cases. This is the purpose of `returning` in
 function definitions.
 
-</aside>
+:::
 
 
 ### Defining Arrays
@@ -862,8 +862,8 @@ memory. They are also fully supported in Ctypes, but we won't go into more
 detail here. [operators/controlling pointers]{.idx}[pointers/operators
 controlling]{.idx}
 
-<aside data-type="sidebar">
-<h5>Pointer Operators for Dereferencing and Arithmetic</h5>
+::: {data-type=note}
+##### Pointer Operators for Dereferencing and Arithmetic
 
 Ctypes defines a number of operators that let you manipulate pointers and
 arrays just as you would in C. The Ctypes equivalents do have the benefit of
@@ -886,7 +886,7 @@ Table:  Operators for manipulating pointers and arrays
 There are also other useful nonoperator functions available (see the Ctypes
 documentation), such as pointer differencing and comparison.
 
-</aside>
+:::
 
 
 ## Passing Functions to C
@@ -1048,8 +1048,8 @@ scope since we opened `Ctypes` at the start of the file.[memory/and allocated
 Ctypes]{.idx}[Ctypes library/lifetime of allocated Ctypes]{.idx}[garbage
 collection/of allocated Ctypes]{.idx}
 
-<aside data-type="sidebar">
-<h5>Lifetime of Allocated Ctypes</h5>
+::: {data-type=note}
+##### Lifetime of Allocated Ctypes
 
 Values allocated via Ctypes (i.e., using `allocate`, `Array.make`, and so on)
 will not be garbage-collected as long as they are reachable from OCaml
@@ -1084,7 +1084,7 @@ function pointers in global variables or elsewhere, in which case you'll need
 to take care that the OCaml functions you pass to them aren't prematurely
 garbage-collected.
 
-</aside>
+:::
 
 
 ## Learning More About C Bindings

--- a/book/garbage-collector/README.md
+++ b/book/garbage-collector/README.md
@@ -64,8 +64,8 @@ major and minor heaps to account for this generational difference. We'll
 explain how they differ in more detail next. [OCAMLRUNPARAM]{.idx}[Gc
 module]{.idx}
 
-<aside data-type="sidebar">
-<h5>The Gc Module and OCAMLRUNPARAM</h5>
+::: {data-type=note}
+##### The Gc Module and OCAMLRUNPARAM
 
 OCaml provides several mechanisms to query and alter the behavior of the
 runtime system. The `Gc` module provides this functionality from within OCaml
@@ -81,7 +81,7 @@ effects of different settings. The format of `OCAMLRUNPARAM` is documented in
 the
 [ OCaml manual](https://caml.inria.fr/pub/docs/manual-ocaml/runtime.html).
 
-</aside>
+:::
 
 ## The Fast Minor Heap
 

--- a/book/imperative-programming/README.md
+++ b/book/imperative-programming/README.md
@@ -1309,8 +1309,8 @@ Error: This expression has type float but an expression was expected of type
          int
 ```
 
-<aside data-type="sidebar">
-<h5>Understanding Format Strings</h5>
+::: {data-type=note}
+##### Understanding Format Strings
 
 The format strings used by `printf` turn out to be quite different from
 ordinary strings. This difference ties to the fact that OCaml format strings,
@@ -1366,7 +1366,7 @@ time, you don't need to know about this special handling of format
 strings—you can just use `printf` and not worry about the details. But it's
 useful to keep the broad outlines of the story in the back of your head.
 
-</aside>
+:::
 
 Now let's see how we can rewrite our time conversion program to be a little
 more concise using `printf`:

--- a/book/json/README.md
+++ b/book/json/README.md
@@ -265,8 +265,8 @@ This code introduces the `Yojson.Basic.Util` module, which contains
 strongly typed OCaml value. [combinators/functional
 combinators]{.idx}[functional combinators]{.idx}
 
-<aside data-type="sidebar">
-<h5>Functional Combinators</h5>
+::: {data-type=note}
+##### Functional Combinators
 
 Combinators are a design pattern that crops up quite often in functional
 programming. John Hughes defines them as "a function which builds program
@@ -296,7 +296,7 @@ imperative code. The input function is applied to every value, but no result
 is supplied. The function must instead apply some side effect such as
 changing a mutable record field or printing to the standard output.
 
-</aside>
+:::
 
 `Yojson` provides several combinators in the `Yojson.Basic.Util` module, some
 of which are listed in [Table15_1](json.html#table15_1){data-type=xref}.
@@ -477,8 +477,8 @@ reliability, as all the uses of polymorphic variants are still checked at
 compile time. [errors/type errors]{.idx}[type checking]{.idx}[polymorphic
 variant types/type checking and]{.idx}[type inference/benefits of]{.idx}
 
-<aside data-type="sidebar">
-<h5>Polymorphic Variants and Easier Type Checking</h5>
+::: {data-type=note}
+##### Polymorphic Variants and Easier Type Checking
 
 One difficulty you will encounter is that type errors involving polymorphic
 variants can be quite verbose. For example, suppose you build an `Assoc` and
@@ -520,7 +520,7 @@ We'll discuss more techniques like this that help you interpret type errors
 more easily in
 [The Compiler Frontend Parsing And Type Checking](compiler-frontend.html#the-compiler-frontend-parsing-and-type-checking){data-type=xref}.
 
-</aside>
+:::
 
 ## Using Nonstandard JSON Extensions {#using-non-standard-json-extensions}
 

--- a/book/lists-and-patterns/README.md
+++ b/book/lists-and-patterns/README.md
@@ -851,8 +851,8 @@ check on whether the first two elements are equal:
 val destutter : int list -> int list = <fun>
 ```
 
-<aside data-type="sidebar">
-<h5>Polymorphic Compare</h5>
+::: {data-type=note}
+##### Polymorphic Compare
 
 You might have noticed that `destutter` is specialized to lists of integers.
 That's because `Base`'s default equality operator is specialized to integers,
@@ -949,7 +949,7 @@ the module again.
 # open Base
 ```
 
-</aside>
+:::
 
 Note that `when` clauses have some downsides. As we noted earlier, the static
 checks associated with pattern matches rely on the fact that patterns are

--- a/book/maps-and-hashtables/README.md
+++ b/book/maps-and-hashtables/README.md
@@ -388,7 +388,7 @@ Error: This expression has type
        but an expression was expected of type
          (string, int, String.comparator_witness) Map.t
        Type Reverse.comparator_witness is not compatible with type
-         String.comparator_witness
+         String.comparator_witness 
 ```
 
 ### The Polymorphic Comparator
@@ -419,7 +419,7 @@ Error: This expression has type (int, string, Int.comparator_witness) Map.t
        but an expression was expected of type
          (int, string, Comparator.Poly.comparator_witness) Map.t
        Type Int.comparator_witness is not compatible with type
-         Comparator.Poly.comparator_witness
+         Comparator.Poly.comparator_witness 
 ```
 
 This is rejected for good reason: there's no guarantee that the comparator
@@ -725,7 +725,7 @@ Error: This expression has type
          (string, int, Reverse.comparator_witness)
          Core_kernel.Map_intf.Tree.t
        Type String.comparator_witness is not compatible with type
-         Reverse.comparator_witness
+         Reverse.comparator_witness 
 ```
 
 ## Hash Tables

--- a/book/maps-and-hashtables/README.md
+++ b/book/maps-and-hashtables/README.md
@@ -388,7 +388,7 @@ Error: This expression has type
        but an expression was expected of type
          (string, int, String.comparator_witness) Map.t
        Type Reverse.comparator_witness is not compatible with type
-         String.comparator_witness 
+         String.comparator_witness
 ```
 
 ### The Polymorphic Comparator
@@ -419,15 +419,15 @@ Error: This expression has type (int, string, Int.comparator_witness) Map.t
        but an expression was expected of type
          (int, string, Comparator.Poly.comparator_witness) Map.t
        Type Int.comparator_witness is not compatible with type
-         Comparator.Poly.comparator_witness 
+         Comparator.Poly.comparator_witness
 ```
 
 This is rejected for good reason: there's no guarantee that the comparator
 associated with a given type will order things in the same way that
 polymorphic compare does.
 
-<aside data-type="sidebar">
-<h5>The Perils of Polymorphic Compare</h5>
+::: {data-type=warning}
+##### The Perils of Polymorphic Compare
 
 Polymorphic compare is highly convenient, but it has serious downsides as
 well and should be used with care. In particular, polymorphic compare has a
@@ -497,7 +497,7 @@ together. Even worse, it will work sometimes and fail others; since if the
 sets are built in a consistent order, then they will work as expected, but
 once the order changes, the behavior will change.
 
-</aside>
+:::
 
 ### Satisfying `Comparator.S` with `[@@deriving]` {#satsifying-comparator.s-with-deriving}
 
@@ -580,8 +580,8 @@ you can always write your own comparison function by hand; but if all you
 need is a total order suitable for creating maps and sets with, then
 `[@@deriving compare]` is a good choice.
 
-<aside data-type="sidebar">
-<h5>=, ==, and phys_equal</h5>
+::: {data-type=note}
+##### =, ==, and phys_equal
 
 If you come from a C/C++ background, you'll probably reflexively use
 `==` to test two values for equality. In OCaml, the `==` operator tests for
@@ -632,7 +632,7 @@ and t2 = { foo2 : int; bar2 : t1; }
 <press ^Z and kill the process now>
 ```
 
-</aside>
+:::
 
 ### Applying `[@@deriving]` to maps and sets
 
@@ -725,7 +725,7 @@ Error: This expression has type
          (string, int, Reverse.comparator_witness)
          Core_kernel.Map_intf.Tree.t
        Type String.comparator_witness is not compatible with type
-         Reverse.comparator_witness 
+         Reverse.comparator_witness
 ```
 
 ## Hash Tables

--- a/book/objects/README.md
+++ b/book/objects/README.md
@@ -9,8 +9,8 @@ you to classes and inheritance. [objects/in object-oriented
 programming]{.idx}[object-oriented programming
 (OOP)]{.idx}[programming/object-oriented programming (OOP)]{.idx}
 
-<aside data-type="sidebar">
-<h5>What Is Object-Oriented Programming?</h5>
+::: {data-type=note}
+##### What Is Object-Oriented Programming?
 
 Object-oriented programming (often shortened to OOP) is a programming style
 that encapsulates computation and data within logical *objects*. Each object
@@ -53,7 +53,7 @@ Almost every notable modern programming language has been influenced by OOP,
 and you'll have run across these terms if you've ever used C++, Java, C#,
 Ruby, Python, or JavaScript.
 
-</aside>
+:::
 
 ## OCaml Objects
 
@@ -470,9 +470,9 @@ this and does not allow the coercion:
 val square_array : square array = [|<obj>; <obj>|]
 # let shape_array: shape array = (square_array :> shape array)
 Characters 31-60:
-Error: Type square array is not a subtype of shape array 
+Error: Type square array is not a subtype of shape array
        Type square = < area : float; width : int >
-       is not compatible with type shape = < area : float > 
+       is not compatible with type shape = < area : float >
        The second object type has no method width
 ```
 
@@ -498,8 +498,8 @@ We say that `'a -> string` is *contravariant* in `'a`. In general, function
 types are contravariant in their arguments and covariant in their results.
 [contravariance]{.idx}
 
-<aside data-type="sidebar">
-<h5>Variance Annotations</h5>
+::: {data-type=note}
+##### Variance Annotations
 
 OCaml works out the variance of a type using that type's definition:
 
@@ -543,7 +543,7 @@ Error: This expression cannot be coerced to type
        it has type (< area : float; width : int >, 'a) AbstractEither.t
        but is here used with type (shape, shape) AbstractEither.t
        Type < area : float; width : int > is not compatible with type
-         shape = < area : float > 
+         shape = < area : float >
        The second object type has no method width
 ```
 
@@ -566,7 +566,7 @@ module VarEither :
 - : (shape, shape) VarEither.t = <abstr>
 ```
 
-</aside>
+:::
 
 For a more concrete example of variance, let's create some stacks containing
 shapes by applying our `stack` function to some squares and some circles:
@@ -603,9 +603,9 @@ However, when we try to apply this function to our objects, we get an error:
 Characters 12-41:
 Error: Type square stack = < pop : square option; push : square -> unit >
        is not a subtype of
-         shape stack = < pop : shape option; push : shape -> unit > 
+         shape stack = < pop : shape option; push : shape -> unit >
        Type shape = < area : float > is not a subtype of
-         square = < area : float; width : int > 
+         square = < area : float; width : int >
 ```
 
 As you can see, `square stack` and `circle stack` are not subtypes of

--- a/book/objects/README.md
+++ b/book/objects/README.md
@@ -470,9 +470,9 @@ this and does not allow the coercion:
 val square_array : square array = [|<obj>; <obj>|]
 # let shape_array: shape array = (square_array :> shape array)
 Characters 31-60:
-Error: Type square array is not a subtype of shape array
+Error: Type square array is not a subtype of shape array 
        Type square = < area : float; width : int >
-       is not compatible with type shape = < area : float >
+       is not compatible with type shape = < area : float > 
        The second object type has no method width
 ```
 
@@ -543,7 +543,7 @@ Error: This expression cannot be coerced to type
        it has type (< area : float; width : int >, 'a) AbstractEither.t
        but is here used with type (shape, shape) AbstractEither.t
        Type < area : float; width : int > is not compatible with type
-         shape = < area : float >
+         shape = < area : float > 
        The second object type has no method width
 ```
 
@@ -603,9 +603,9 @@ However, when we try to apply this function to our objects, we get an error:
 Characters 12-41:
 Error: Type square stack = < pop : square option; push : square -> unit >
        is not a subtype of
-         shape stack = < pop : shape option; push : shape -> unit >
+         shape stack = < pop : shape option; push : shape -> unit > 
        Type shape = < area : float > is not a subtype of
-         square = < area : float; width : int >
+         square = < area : float; width : int > 
 ```
 
 As you can see, `square stack` and `circle stack` are not subtypes of

--- a/examples/code/back-end/pattern_monomorphic_small.ml
+++ b/examples/code/back-end/pattern_monomorphic_small.ml
@@ -1,4 +1,4 @@
-type t = | Alice | Bob 
+type t = | Alice | Bob
 
 let test v =
   match v with


### PR DESCRIPTION
Most with notes, one with a warning. Asides (in this case, marked as sidebars) are currently ignored, and it's not clear what distinction is intended between sidebar and note.

The diff is easier to read if you turn off whitespace in the diff.  Some whitespace-only changes were made because my editor is configured to remove trailing whitespace on save. 