### PR TITLE
Swap promotion direction for extracted ocaml blocks

### DIFF
--- a/book/classes/README.md
+++ b/book/classes/README.md
@@ -843,7 +843,7 @@ for now you can safely ignore the details. You just need to run
 We will give each shape a `draw` method that describes how to draw the shape
 on the `Async_graphics` display:
 
-```ocaml file=examples/shapes/shapes.ml
+```ocaml file=examples/shapes/shapes.ml,part=0
 open Core
 open Async
 open Async_graphics

--- a/book/classes/dune
+++ b/book/classes/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/classes/dune.inc
+++ b/book/classes/dune.inc
@@ -17,7 +17,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y3} %{y3}.corrected)
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)

--- a/book/classes/examples/shapes/shapes.ml
+++ b/book/classes/examples/shapes/shapes.ml
@@ -1,3 +1,4 @@
+[@@@part "0"] ;;
 open Core
 open Async
 open Async_graphics

--- a/book/command-line-parsing/README.md
+++ b/book/command-line-parsing/README.md
@@ -44,7 +44,7 @@ a file, applies the MD5 one-way cryptographic hash function to the data, and
 outputs an ASCII hex representation of the result: [MD5 one-way cryptographic
 hash function]{.idx}[command-line parsing/basic approach to]{.idx}
 
-```ocaml file=examples/command-line-parsing/md5/md5.ml
+```ocaml file=examples/command-line-parsing/md5/md5.ml,part=0
 open Core
 
 let do_hash file =
@@ -208,7 +208,7 @@ argument and the MD5 output is displayed to the standard output.
 
 ```sh dir=examples/command-line-parsing/md5
 $ dune exec -- ./md5.exe md5.ml
-fdac6d086494068b8c22ddf38d19c51d
+cd43f59095550dce382f8f3427aa3373
 ```
 
 And that's all it took to build our little MD5 utility! Here's a complete

--- a/book/command-line-parsing/dune
+++ b/book/command-line-parsing/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude prelude.ml))))
 
 (alias

--- a/book/command-line-parsing/dune.inc
+++ b/book/command-line-parsing/dune.inc
@@ -39,7 +39,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y15} %{y15}.corrected)
            (diff? %{y14} %{y14}.corrected)
            (diff? %{y13} %{y13}.corrected)
@@ -94,7 +94,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y15} %{y15}.corrected)
            (diff? %{y14} %{y14}.corrected)
            (diff? %{y13} %{y13}.corrected)

--- a/book/command-line-parsing/examples/command-line-parsing/md5/md5.ml
+++ b/book/command-line-parsing/examples/command-line-parsing/md5/md5.ml
@@ -1,3 +1,4 @@
+[@@@part "0"];;
 open Core
 
 let do_hash file =

--- a/book/compiler-backend/dune
+++ b/book/compiler-backend/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/compiler-backend/dune.inc
+++ b/book/compiler-backend/dune.inc
@@ -27,7 +27,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y9} %{y9}.corrected)
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
@@ -64,7 +64,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y9} %{y9}.corrected)
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)

--- a/book/compiler-frontend/dune
+++ b/book/compiler-frontend/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/compiler-frontend/dune.inc
+++ b/book/compiler-frontend/dune.inc
@@ -31,7 +31,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y14} %{y14}.corrected)
            (diff? %{y13} %{y13}.corrected)
            (diff? %{y12} %{y12}.corrected)
@@ -77,7 +77,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y14} %{y14}.corrected)
            (diff? %{y13} %{y13}.corrected)
            (diff? %{y12} %{y12}.corrected)

--- a/book/concurrent-programming/README.md
+++ b/book/concurrent-programming/README.md
@@ -436,7 +436,7 @@ a convenient abstraction for working with input and output channels: [Writer
 module]{.idx}[Reader module]{.idx}[I/O (input/output) operations/copying
 data]{.idx}
 
-```ocaml file=examples/echo/echo.ml
+```ocaml file=examples/echo/echo.ml,part=0
 open Core
 open Async
 
@@ -818,7 +818,7 @@ engine/URI handling in]{.idx}
 We'll need a function for generating the URIs that we're going to use to
 query the DuckDuckGo servers:
 
-```ocaml file=examples/search/search.ml
+```ocaml file=examples/search/search.ml,part=0
 open Core
 open Async
 

--- a/book/concurrent-programming/dune
+++ b/book/concurrent-programming/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/concurrent-programming/dune.inc
+++ b/book/concurrent-programming/dune.inc
@@ -31,7 +31,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
            (diff? %{y6} %{y6}.corrected)
@@ -71,7 +71,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
            (diff? %{y6} %{y6}.corrected)

--- a/book/concurrent-programming/examples/echo/echo.ml
+++ b/book/concurrent-programming/examples/echo/echo.ml
@@ -1,3 +1,4 @@
+[@@@part "0"];;
 open Core
 open Async
 

--- a/book/concurrent-programming/examples/search/search.ml
+++ b/book/concurrent-programming/examples/search/search.ml
@@ -1,3 +1,4 @@
+[@@@part "0"];;
 open Core
 open Async
 

--- a/book/data-serialization/dune
+++ b/book/data-serialization/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/data-serialization/dune.inc
+++ b/book/data-serialization/dune.inc
@@ -26,7 +26,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
            (diff? %{y6} %{y6}.corrected)
@@ -61,7 +61,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
            (diff? %{y6} %{y6}.corrected)

--- a/book/error-handling/dune
+++ b/book/error-handling/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/error-handling/dune.inc
+++ b/book/error-handling/dune.inc
@@ -17,7 +17,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected)
@@ -37,7 +37,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected)

--- a/book/files-modules-and-programs/dune
+++ b/book/files-modules-and-programs/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/files-modules-and-programs/dune.inc
+++ b/book/files-modules-and-programs/dune.inc
@@ -45,7 +45,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y21} %{y21}.corrected)
            (diff? %{y20} %{y20}.corrected)
            (diff? %{y19} %{y19}.corrected)
@@ -112,7 +112,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y21} %{y21}.corrected)
            (diff? %{y20} %{y20}.corrected)
            (diff? %{y19} %{y19}.corrected)

--- a/book/first-class-modules/dune
+++ b/book/first-class-modules/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/first-class-modules/dune.inc
+++ b/book/first-class-modules/dune.inc
@@ -16,7 +16,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected)
@@ -35,7 +35,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected)

--- a/book/foreign-function-interface/README.md
+++ b/book/foreign-function-interface/README.md
@@ -101,7 +101,7 @@ OCaml value.
 Let's begin by defining the basic values we need, starting with the `WINDOW`
 state pointer:
 
-```ocaml file=examples/ffi/ncurses/ncurses.ml
+```ocaml file=examples/ffi/ncurses/ncurses.ml,part=0
 open Ctypes
 
 type window = unit ptr
@@ -267,7 +267,7 @@ First, let's look at how to define basic scalar C types. Every C type is
 represented by an OCaml equivalent via the single type definition:[scalar C
 types]{.idx}[foreign function interface (FFI)/basic scalar C types]{.idx}
 
-```ocaml file=examples/ctypes/ctypes.mli
+```ocaml file=examples/ctypes/ctypes.mli,part=0
 type 'a typ
 ```
 
@@ -750,7 +750,7 @@ Tue Mar  6 13:27:51 2018
 The alert reader may be curious about why all these function definitions have
 to be terminated by `returning`:
 
-```ocaml file=examples/ffi/return_frag.ml
+```ocaml file=examples/ffi/return_frag.ml,part=0
 (* correct types *)
 val time: ptr time_t @-> returning time_t
 val difftime: time_t @-> time_t @-> returning double

--- a/book/foreign-function-interface/dune
+++ b/book/foreign-function-interface/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/foreign-function-interface/dune.inc
+++ b/book/foreign-function-interface/dune.inc
@@ -27,7 +27,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
            (diff? %{y6} %{y6}.corrected)
@@ -63,7 +63,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
            (diff? %{y6} %{y6}.corrected)

--- a/book/foreign-function-interface/examples/ctypes/ctypes.mli
+++ b/book/foreign-function-interface/examples/ctypes/ctypes.mli
@@ -1,3 +1,4 @@
+[@@@part "0"];;
 type 'a typ
 
 [@@@part "1"] ;;

--- a/book/foreign-function-interface/examples/ffi/ncurses/ncurses.ml
+++ b/book/foreign-function-interface/examples/ffi/ncurses/ncurses.ml
@@ -1,3 +1,4 @@
+[@@@part "0"];;
 open Ctypes
 
 type window = unit ptr

--- a/book/foreign-function-interface/examples/ffi/return_frag.ml
+++ b/book/foreign-function-interface/examples/ffi/return_frag.ml
@@ -1,3 +1,4 @@
+[@@@part "0"];;
 (* correct types *)
 val time: ptr time_t @-> returning time_t
 val difftime: time_t @-> time_t @-> returning double

--- a/book/functors/dune
+++ b/book/functors/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/functors/dune.inc
+++ b/book/functors/dune.inc
@@ -19,7 +19,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y6} %{y6}.corrected)
            (diff? %{y5} %{y5}.corrected)
            (diff? %{y4} %{y4}.corrected)

--- a/book/garbage-collector/dune
+++ b/book/garbage-collector/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/garbage-collector/dune.inc
+++ b/book/garbage-collector/dune.inc
@@ -18,7 +18,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected)
            (diff? %{x} %{x}.corrected))))
@@ -38,7 +38,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected)
            (diff? %{x} %{x}.corrected))))

--- a/book/guided-tour/dune
+++ b/book/guided-tour/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/guided-tour/dune.inc
+++ b/book/guided-tour/dune.inc
@@ -15,7 +15,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected)
            (diff? %{x} %{x}.corrected))))

--- a/book/imperative-programming/dune
+++ b/book/imperative-programming/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
                 --prelude=%{dep:prelude.ml}
                 --prelude=memo:%{dep:memo.ml}
                 --prelude=fib:%{dep:fib.ml}

--- a/book/imperative-programming/dune.inc
+++ b/book/imperative-programming/dune.inc
@@ -24,7 +24,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=memo:memo.ml --prelude=fib:fib.ml --prelude=letrec:letrec.ml --prelude=value_restriction:letrec.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=memo:memo.ml --prelude=fib:fib.ml --prelude=letrec:letrec.ml --prelude=value_restriction:letrec.ml --direction=to-md %{x}))
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
            (diff? %{y6} %{y6}.corrected)
@@ -57,7 +57,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=memo:memo.ml --prelude=fib:fib.ml --prelude=letrec:letrec.ml --prelude=value_restriction:letrec.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=memo:memo.ml --prelude=fib:fib.ml --prelude=letrec:letrec.ml --prelude=value_restriction:letrec.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y8} %{y8}.corrected)
            (diff? %{y7} %{y7}.corrected)
            (diff? %{y6} %{y6}.corrected)

--- a/book/json/README.md
+++ b/book/json/README.md
@@ -95,7 +95,7 @@ The JSON specification has very few data types, and the `Yojson.Basic.t`
 type that follows is sufficient to express any valid JSON structure: [JSON
 data/parsing with Yojson]{.idx}[Yojson library/parsing JSON with]{.idx}
 
-```ocaml file=yojson_basic.mli
+```ocaml file=yojson_basic.mli,part=0
 type json = [
   | `Assoc of (string * json) list
   | `Bool of bool
@@ -276,7 +276,7 @@ transformations over values.
 
 You've already run across several of these in the `List` module:
 
-```ocaml file=list_excerpt.mli
+```ocaml file=list_excerpt.mli,part=0
 val map  : 'a list -> f:('a -> 'b)   -> 'b list
 val fold : 'a list -> init:'accum -> f:('accum -> 'a -> 'accum) -> 'accum
 ```
@@ -418,7 +418,7 @@ call the `to_string` function on them. Let's remind ourselves of the
 `Yojson.Basic.t` type again: [values/in JSON data]{.idx}[JSON
 data/constructing values]{.idx}
 
-```ocaml file=yojson_basic.mli
+```ocaml file=yojson_basic.mli,part=0
 type json = [
   | `Assoc of (string * json) list
   | `Bool of bool
@@ -531,7 +531,7 @@ human-readable, local format. The `Yojson.Safe.json` type is a superset of
 the `Basic` polymorphic variant and looks like this: [Yojson library/extended
 JSON format support]{.idx}[JSON data/nonstandard extensions for]{.idx}
 
-```ocaml file=yojson_safe.mli
+```ocaml file=yojson_safe.mli,part=0
 type json = [
   | `Assoc of (string * json) list
   | `Bool of bool

--- a/book/json/dune
+++ b/book/json/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
                 --root examples/json
                 --prelude=%{dep:prelude.ml}))))
 

--- a/book/json/dune.inc
+++ b/book/json/dune.inc
@@ -22,7 +22,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --root=examples/json %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --root=examples/json %{x}))
            (diff? %{y7} %{y7}.corrected)
            (diff? %{y6} %{y6}.corrected)
            (diff? %{y5} %{y5}.corrected)
@@ -52,7 +52,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic --root=examples/json %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic --root=examples/json %{x}))
            (diff? %{y7} %{y7}.corrected)
            (diff? %{y6} %{y6}.corrected)
            (diff? %{y5} %{y5}.corrected)

--- a/book/json/examples/json/list_excerpt.mli
+++ b/book/json/examples/json/list_excerpt.mli
@@ -1,3 +1,4 @@
+[@@@part "0"];;
 val map  : 'a list -> f:('a -> 'b)   -> 'b list
 val fold : 'a list -> init:'accum -> f:('accum -> 'a -> 'accum) -> 'accum
 

--- a/book/json/examples/json/yojson_basic.mli
+++ b/book/json/examples/json/yojson_basic.mli
@@ -1,3 +1,4 @@
+[@@@part "0"];;
 type json = [
   | `Assoc of (string * json) list
   | `Bool of bool

--- a/book/json/examples/json/yojson_safe.mli
+++ b/book/json/examples/json/yojson_safe.mli
@@ -1,3 +1,4 @@
+[@@@part "0"];;
 type json = [
   | `Assoc of (string * json) list
   | `Bool of bool

--- a/book/lists-and-patterns/dune
+++ b/book/lists-and-patterns/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/lists-and-patterns/dune.inc
+++ b/book/lists-and-patterns/dune.inc
@@ -13,7 +13,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
 
            (diff? %{x} %{x}.corrected))))
 (alias
@@ -27,6 +27,6 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
 
            (diff? %{x} %{x}.corrected))))

--- a/book/maps-and-hashtables/dune
+++ b/book/maps-and-hashtables/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/maps-and-hashtables/dune.inc
+++ b/book/maps-and-hashtables/dune.inc
@@ -18,7 +18,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y3} %{y3}.corrected)
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)
@@ -40,7 +40,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y3} %{y3}.corrected)
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)

--- a/book/objects/dune
+++ b/book/objects/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
                 --prelude=%{dep:prelude.ml}
                 --prelude=%{dep:subtyping.ml}))))
 

--- a/book/objects/dune.inc
+++ b/book/objects/dune.inc
@@ -16,7 +16,7 @@
          subtyping.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=subtyping.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=subtyping.ml --direction=to-md %{x}))
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected)
@@ -35,7 +35,7 @@
          subtyping.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=subtyping.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=subtyping.ml --direction=to-md --non-deterministic %{x}))
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)
            (diff? %{y0} %{y0}.corrected)

--- a/book/parsing-with-ocamllex-and-menhir/README.md
+++ b/book/parsing-with-ocamllex-and-menhir/README.md
@@ -653,7 +653,7 @@ parsing errors. There are currently two errors: `Parser.Error` and
 `Lexer.SyntaxError`. A simple solution when encountering an error is to print
 the error and give up: [errors/"give up on first error" approach]{.idx}
 
-```ocaml file=examples/parsing-test/test.ml
+```ocaml file=examples/parsing-test/test.ml,part=0
 open Core
 open Lexer
 open Lexing

--- a/book/parsing-with-ocamllex-and-menhir/dune
+++ b/book/parsing-with-ocamllex-and-menhir/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/parsing-with-ocamllex-and-menhir/dune.inc
+++ b/book/parsing-with-ocamllex-and-menhir/dune.inc
@@ -20,7 +20,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y5} %{y5}.corrected)
            (diff? %{y4} %{y4}.corrected)
            (diff? %{y3} %{y3}.corrected)

--- a/book/parsing-with-ocamllex-and-menhir/examples/parsing-test/test.ml
+++ b/book/parsing-with-ocamllex-and-menhir/examples/parsing-test/test.ml
@@ -1,3 +1,4 @@
+[@@@part "0"] ;;
 open Core
 open Lexer
 open Lexing

--- a/book/ppx/dune
+++ b/book/ppx/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/ppx/dune.inc
+++ b/book/ppx/dune.inc
@@ -12,6 +12,6 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
 
            (diff? %{x} %{x}.corrected))))

--- a/book/prologue/dune
+++ b/book/prologue/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}))))
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}))))
 
 (alias
  (name   runtest)

--- a/book/prologue/dune.inc
+++ b/book/prologue/dune.inc
@@ -9,6 +9,6 @@
          (package mdx))
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --direction=to-md %{x}))
 
            (diff? %{x} %{x}.corrected))))

--- a/book/records/dune
+++ b/book/records/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/records/dune.inc
+++ b/book/records/dune.inc
@@ -13,7 +13,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
 
            (diff? %{x} %{x}.corrected))))
 (alias
@@ -27,6 +27,6 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml --non-deterministic %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md --non-deterministic %{x}))
 
            (diff? %{x} %{x}.corrected))))

--- a/book/runtime-memory-layout/dune
+++ b/book/runtime-memory-layout/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/runtime-memory-layout/dune.inc
+++ b/book/runtime-memory-layout/dune.inc
@@ -11,6 +11,6 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
 
            (diff? %{x} %{x}.corrected))))

--- a/book/variables-and-functions/dune
+++ b/book/variables-and-functions/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}))))
 
 (alias

--- a/book/variables-and-functions/dune.inc
+++ b/book/variables-and-functions/dune.inc
@@ -18,7 +18,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --direction=to-md %{x}))
            (diff? %{y5} %{y5}.corrected)
            (diff? %{y4} %{y4}.corrected)
            (diff? %{y3} %{y3}.corrected)

--- a/book/variants/dune
+++ b/book/variants/dune
@@ -2,7 +2,7 @@
   (target dune.gen)
   (action
    (with-stdout-to %{target}
-    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-ml %{dep:README.md}
+    (run ocaml-mdx rule --locks ../../global-lock --duniverse-mode --direction=to-md %{dep:README.md}
       --prelude=%{dep:prelude.ml}
       --prelude=catch_all:%{dep:catch_all.ml}
       --prelude=logger:%{dep:logger.ml}))))

--- a/book/variants/dune.inc
+++ b/book/variants/dune.inc
@@ -19,7 +19,7 @@
          prelude.ml)
  (locks ../../global-lock)
  (action (progn
-           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=catch_all:catch_all.ml --prelude=logger:logger.ml --direction=to-ml %{x}))
+           (setenv OCAMLFIND_CONF %{conf} (run ocaml-mdx test --prelude=prelude.ml --prelude=catch_all:catch_all.ml --prelude=logger:logger.ml --direction=to-md %{x}))
            (diff? %{y3} %{y3}.corrected)
            (diff? %{y2} %{y2}.corrected)
            (diff? %{y1} %{y1}.corrected)


### PR DESCRIPTION
Closes #3139.

This PR swaps the default direction for `ocaml` blocks that are kept in sync with example files. We used to consider the markdown files as the source of truth but it turns out it is quite inconvenient.

Some examples needed to be labeled a bit differentely because of how `mdx` seems to handle this direction but in the end I believe it's better as now all parts that are used in chapters are explicitly delimited in the `.ml`/`,mli` files.