### PR TITLE
Objects: typo in subtyping example (**) instead of (**.)

### DIFF
--- a/book/objects/README.md
+++ b/book/objects/README.md
@@ -370,7 +370,7 @@ end
 type circle = < area : float; radius : int >
 
 let circle r = object
-  method area = 3.14 *. (Float.of_int r) ** 2.0
+  method area = 3.14 *. (Float.of_int r) **. 2.0
   method radius = r
 end
 ```

--- a/book/objects/examples/subtyping.ml
+++ b/book/objects/examples/subtyping.ml
@@ -13,7 +13,7 @@ end
 type circle = < area : float; radius : int >
 
 let circle r = object
-  method area = 3.14 *. (Float.of_int r) ** 2.0
+  method area = 3.14 *. (Float.of_int r) **. 2.0
   method radius = r
 end
 


### PR DESCRIPTION
The subtyping example uses `**` instead of `**.`. This PR fixes it.