### PR TITLE
json: Use Shell instead of Core_extended.Shell

### DIFF
--- a/book/json/README.md
+++ b/book/json/README.md
@@ -889,17 +889,17 @@ and uses these modules to output a one-line summary. Our following example
 does just that.
 
 The following code calls the cURL command-line utility by using the
-`Core_extended.Shell` interface to run an external command and capture its
+`Shell` interface to run an external command and capture its
 output. You'll need to ensure that you have cURL installed on your system
 before running the example. You might also need to
-`opam install core_extended` if you haven't installed it previously:
+`opam install shell` if you haven't installed it previously:
 
 ```ocaml file=github_org_info/github_org_info.ml
 open Core
 
 let print_org file () =
   let url = sprintf "https://api.github.com/orgs/%s" file in
-  Core_extended.Shell.run_full "curl" [url]
+  Shell.run_full "curl" [url]
   |> Github_org_j.org_of_string
   |> fun org ->
   let open Github_org_t in

--- a/book/json/examples/json/github_org_info/dune
+++ b/book/json/examples/json/github_org_info/dune
@@ -12,6 +12,6 @@
 
 (executable
   (name      github_org_info)
-  (libraries core yojson atdgen core_extended)
+  (libraries core yojson atdgen shell)
   (flags     :standard -w -32)
   (modules   github_org_info github_org_t github_org_j))

--- a/book/json/examples/json/github_org_info/github_org_info.ml
+++ b/book/json/examples/json/github_org_info/github_org_info.ml
@@ -2,7 +2,7 @@ open Core
 
 let print_org file () =
   let url = sprintf "https://api.github.com/orgs/%s" file in
-  Core_extended.Shell.run_full "curl" [url]
+  Shell.run_full "curl" [url]
   |> Github_org_j.org_of_string
   |> fun org ->
   let open Github_org_t in


### PR DESCRIPTION
In summary, the `Core_extended.Shell` seems to have been moved to its
own library `shell`.
See https://discuss.ocaml.org/t/ann-v0-12-release-of-jane-street-packages/3499

The `core_extended` library https://github.com/janestreet/core_extended
has reorganised their code
https://discuss.ocaml.org/t/ann-v0-12-release-of-jane-street-packages/3499

While trying the `github_org_info` example I ran into the following
problem:

```
dune exec -- ./github_org_info.exe janestreet
File "dune", line 15, characters 32-45:
15 |   (libraries core yojson atdgen core_extended)
                                     ^^^^^^^^^^^^^
Error: Library "core_extended" not found.
Hint: try: dune external-lib-deps --missing ./github_org_info.exe
```

Similar to https://github.com/janestreet/core_extended/issues/22 the
`core_extended` library was installed:

```
$ ocamlfind list | grep core_extended
core_extended       (version: n/a)
core_extended.base64 (version: v0.12.0)
core_extended.delimited_kernel (version: v0.12.0)
core_extended.find_files (version: v0.12.0)
core_extended.selection (version: v0.12.0)

$ dune installed-libraries | grep core_extended
core_extended.base64                    (version: v0.12.0)
core_extended.delimited_kernel          (version: v0.12.0)
core_extended.find_files                (version: v0.12.0)
core_extended.selection                 (version: v0.12.0)
```

The solution has been to install the `shell` library and use the `Shell`
module instead of `Core_extended.Shell`.