### PR TITLE
use pos_cnum to reset bol in lexers

### DIFF
--- a/book/parsing-with-ocamllex-and-menhir/README.md
+++ b/book/parsing-with-ocamllex-and-menhir/README.md
@@ -435,7 +435,7 @@ exception SyntaxError of string
 let next_line lexbuf =
   let pos = lexbuf.lex_curr_p in
   lexbuf.lex_curr_p <-
-    { pos with pos_bol = lexbuf.lex_curr_pos;
+    { pos with pos_bol = pos.pos_cnum;
                pos_lnum = pos.pos_lnum + 1
     }
 }

--- a/book/parsing-with-ocamllex-and-menhir/examples/parsing-test/lexer.mll
+++ b/book/parsing-with-ocamllex-and-menhir/examples/parsing-test/lexer.mll
@@ -7,7 +7,7 @@ exception SyntaxError of string
 let next_line lexbuf =
   let pos = lexbuf.lex_curr_p in
   lexbuf.lex_curr_p <-
-    { pos with pos_bol = lexbuf.lex_curr_pos;
+    { pos with pos_bol = pos.pos_cnum;
                pos_lnum = pos.pos_lnum + 1
     }
 }

--- a/book/parsing-with-ocamllex-and-menhir/examples/parsing/lexer.mll
+++ b/book/parsing-with-ocamllex-and-menhir/examples/parsing/lexer.mll
@@ -7,7 +7,7 @@ exception SyntaxError of string
 let next_line lexbuf =
   let pos = lexbuf.lex_curr_p in
   lexbuf.lex_curr_p <-
-    { pos with pos_bol = lexbuf.lex_curr_pos;
+    { pos with pos_bol = pos.pos_cnum;
                pos_lnum = pos.pos_lnum + 1
     }
 }


### PR DESCRIPTION
In the chapter on Parsing with OCamllex and Menhir, the `next_line` helper updates the beginning of line to `lexbuf.lex_curr_pos`. This led to incorrect column numbers for me.  I believe the update should be to ` lexbuf.lex_curr_p.pos_cnum` as done in [`new_line`](https://github.com/ocaml/ocaml/blob/8d76f94aaf531ea19581ca48783ce873a4070848/stdlib/lexing.ml#L225) from [Lexing](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Lexing.html).  A better fix may be to just use `Lexing.new_line` instead of introducing the `next_line` helper, though introducing the helper does give readers a peek into manipulating lexer buffers.