### PR TITLE
upgrade to dune 2.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN git -C /home/opam/opam-repository pull origin master && opam update -uy
 # install non-OCaml dependencies
 COPY Makefile /home/opam/src/.
 RUN make depext
-RUN opam install dune=2.0.0
+RUN opam install dune=2.0.1
 
 #install pandoc
 WORKDIR /tmp


### PR DESCRIPTION
dune 2.0.0 was marked uninstallable in https://github.com/ocaml/opam-repository/pull/15555