### PR TITLE
Bump dune version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ libraries. To set up your RWO development environment you can run:
 
 ```
 opam switch create rwo 4.09.0
-opam install dune=2.0.0
+opam install dune=2.0.1
 ```
 
 ### Generating the HTML


### PR DESCRIPTION
This is related to https://github.com/realworldocaml/book/commit/bcc164581f3e57ce98ec7a286a42c37e9211742d

The README.md file mentions that we can set up the environment by running 
```
opam install dune=2.0.0
```

But this doesn't work anymore
```
> opam install dune=2.0.0
[ERROR] dune = 2.0.0 unmet availability conditions: false
```

This PR simply bumps the dune version to `2.0.1`, which is in line with the [Dockerfile](https://github.com/realworldocaml/book/blob/917b1fdda5f67ad11b8e1e46aa8b681e367dc430/Dockerfile#L13)