### PR TITLE
Use "1.0 /. 3.0" for a third

### DIFF
--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -101,7 +101,7 @@ language, but a few things jump right out at you:
   be a bit of a nuisance, but it has its benefits, since it prevents some
   kinds of bugs that arise in other languages due to unexpected differences
   between the behavior of `int` and `float`. For example, in many languages,
-  `1 / 3` is zero, but `1 / 3.0` is a third. OCaml requires you to be
+  `1 / 3` is zero, but `1.0 /. 3.0` is a third. OCaml requires you to be
   explicit about which operation you're using.
 
 We can also create a variable to name the value of a given expression, using


### PR DESCRIPTION
In the "OCaml as a Calculator" section, the text should read "1.0 /. 3.0 is a third", instead of "1 / 3.0".

```
utop> 1.0 /. 3.0;;
- : float = 0.33333333333333331
```