### PR TITLE
Use z instead of x in Nesting Lets with Let and In

### DIFF
--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -804,18 +804,18 @@ within which the new variable can be used. Thus, we could write:[let
 syntax/nested let binding]{.idx}
 
 ```ocaml env=local_let
-# let x = 7 in
-  x + x
+# let z = 7 in
+  z + z
 - : int = 14
 ```
 
 Note that the scope of the `let` binding is terminated by the
-double-semicolon, so the value of `x` is no longer available:
+double-semicolon, so the value of `z` is no longer available:
 
 ```ocaml env=local_let
-# x
+# z
 Line 1, characters 1-2:
-Error: Unbound value x
+Error: Unbound value z
 ```
 
 We can also have multiple `let` statements in a row, each one adding a new

--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -803,7 +803,7 @@ including a function body. The `in` marks the beginning of the scope
 within which the new variable can be used. Thus, we could write:[let
 syntax/nested let binding]{.idx}
 
-```ocaml env=local_let
+```ocaml env=main
 # let z = 7 in
   z + z
 - : int = 14
@@ -812,7 +812,7 @@ syntax/nested let binding]{.idx}
 Note that the scope of the `let` binding is terminated by the
 double-semicolon, so the value of `z` is no longer available:
 
-```ocaml env=local_let
+```ocaml env=main
 # z
 Line 1, characters 1-2:
 Error: Unbound value z
@@ -821,7 +821,7 @@ Error: Unbound value z
 We can also have multiple `let` statements in a row, each one adding a new
 variable binding to what came before:
 
-```ocaml env=local_let
+```ocaml env=main
 # let x = 7 in
   let y = x * x in
   x + y


### PR DESCRIPTION
In the "Nesting lets with let and in" section, the value of "x" is '3' instead of the following:
```
  utop> x;;
  Line 1, characters 1-2:
  Error: Unbound value x
```
If one continuously evaluates the chapter examples in a utop session, the value of 'x' gets set as '3' from the "Tuples" section:
```
  let (x,y) = a_tuple;;
  val x : int = 3
  val y : string = "three"
```
Hence, an unused variable "z" is used to illustrate the let binding.