### PR TITLE
Use lowercase txt in Options example

### DIFF
--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -868,7 +868,7 @@ to split on.
       base ^ "." ^ String.lowercase ext
 val downcase_extension : string -> string = <fun>
 # List.map ~f:downcase_extension
-    [ "Hello_World.TXT"; "Hello_World.TXT"; "Hello_World" ]
+    [ "Hello_World.TXT"; "Hello_World.txt"; "Hello_World" ]
 - : string list = ["Hello_World.txt"; "Hello_World.txt"; "Hello_World"]
 ```
 


### PR DESCRIPTION
Why are there two "Hello_World.TXT" strings in this example? Was the second list entry meant to be "Hello_World.txt"?
```
utop> List.map ~f:downcase_extension
        [ "Hello_World.TXT"; "Hello_World.txt"; "Hello_World"]
;;
```