### PR TITLE
Provide example for string option * string in context

### DIFF
--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -887,7 +887,16 @@ everywhere.[datatypes/nullable]{.idx}
 In OCaml, however, missing values are explicit. A value of type
 `string * string` always contains two well-defined values of type `string`.
 If you want to allow, say, the first of those to be absent, then you need to
-change the type to `string option * string`. As we'll see in
+change the type to `string option * string`:
+
+```ocaml env=main
+# Some "File";;
+- : string option = Some "File"
+# (Some "File", "exists");;
+- : string option * string = (Some "File", "exists")
+```
+
+As we'll see in
 [Error Handling](error-handling.html#error-handling){data-type=xref}, this
 explicitness allows the compiler to provide a great deal of help in making
 sure you're correctly handling the possibility of missing data.


### PR DESCRIPTION
It will be good to give an example for "string option * string" in the "Options" section for completion. Moreover, it might take some time for the reader to reach Chapter 7: Error Handling.
```
  utop> Some "File";;
  - : string option = Some "File"

  utop> (Some "File", "exists");;
  - : string option * string = (Some "File", "exists")
```