### PR TITLE
Update Makefile and dune-get for latest duniverse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ depext:
 
 duniverse-init:
 	$(DUNIVERSE) init \
+		--pull-mode source \
 		--pin mdx,https://github.com/realworldocaml/mdx.git,master \
 		rwo \
 		$(DEPS) $(DUNIVERSE_SPECIFIC_DEPS)

--- a/dune-get
+++ b/dune-get
@@ -10,6 +10,7 @@
    (pins
     (((pin mdx) (url (https://github.com/realworldocaml/mdx.git))
       (tag (master)))))
+   (pull_mode source)
    (remotes ()) (branch master)))
  (deps
   ((opamverse ())


### PR DESCRIPTION
Duniverse now allows specifying whether we want to use git submodules or plain source vendoring. This has to be set at `duniverse init` time.

This updates our Makefile targets and our `dune-get` file so that we keep on with our plain vendoring approach.