### PR TITLE
Included (modes byte) to first dune file

### DIFF
--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -138,6 +138,7 @@ specifies the details of the build. [dune]{.idx}
 ```scheme file=examples/freq-dune/dune
 (executable
   (name      freq)
+  (modes byte)
   (libraries base stdio))
 ```
 


### PR DESCRIPTION
You now have to explicitly tell dune that it can compile to bytecode with (modes byte) in the dune file. Updated chapter 4 to reflect this in order to avoid:
`Error: Don't know how to build freq.bc` from `dune build freq.bc`.