### PR TITLE
[Files Modules and Programs] Update freq-dune example to build with dune 2.0

### DIFF
--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -137,7 +137,8 @@ specifies the details of the build. [dune]{.idx}
 
 ```scheme file=examples/freq-dune/dune
 (executable
-  (name      freq)
+  (name freq)
+  (modes byte exe)
   (libraries base stdio))
 ```
 

--- a/book/files-modules-and-programs/examples/freq-dune/dune
+++ b/book/files-modules-and-programs/examples/freq-dune/dune
@@ -1,3 +1,4 @@
 (executable
-  (name      freq)
+  (name freq)
+  (modes byte exe)
   (libraries base stdio))

--- a/book/files-modules-and-programs/examples/freq-dune/dune-project
+++ b/book/files-modules-and-programs/examples/freq-dune/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.0)
+(lang dune 2.0)
 (name rwo-example)


### PR DESCRIPTION
In the "Where is main?" section, the "dune build freq.bc" does not work with dune 2.0. The present file looks like:
```
   (executable
     (name      freq)
     (libraries base stdio))
```
The updated dune file should be:
```
   (executable
     (name freq)
     (modes byte exe)
     (libraries base stdio))
```
Output of `dune runtest` is clean.
Reference: https://github.com/ocaml/dune/issues/3017#issuecomment-572502753