### PR TITLE
[Records] Require ppx_jane and fieldslib for module Logon

### DIFF
--- a/book/records/README.md
+++ b/book/records/README.md
@@ -439,6 +439,8 @@ it is standard practice to name the type associated with the module
 `t`. Using this style we would write:
 
 ```ocaml env=main2
+# #require "ppx_jane"
+# #require "fieldslib"
 # module Log_entry = struct
     type t =
       { session_id: string;

--- a/book/records/dune.inc
+++ b/book/records/dune.inc
@@ -3,6 +3,7 @@
  (deps
   (:x README.md)
   (package core)
+  (package fieldslib)
   (package mdx)
   (package ppx_jane)
   (package re)
@@ -18,6 +19,7 @@
  (deps
   (:x README.md)
   (package core)
+  (package fieldslib)
   (package mdx)
   (package ppx_jane)
   (package re)


### PR DESCRIPTION
Both `ppx_jane` and `fieldslib` are to required in Utop before defining module Logon in the Records chapter.

The following two closed issues are related:
* https://github.com/realworldocaml/book/issues/372
* https://github.com/realworldocaml/book/issues/552

The output of `dune runtest` is clean.