### PR TITLE
Clean examples in variables-and-functions chapter

### DIFF
--- a/book/variables-and-functions/README.md
+++ b/book/variables-and-functions/README.md
@@ -371,7 +371,7 @@ right-associative. The type signature of `abs_diff` can therefore be
 parenthesized as follows. [curried functions]{.idx}[functions/curried
 functions]{.idx}
 
-```ocaml file=examples/abs_diff.mli
+```ocaml skip
 val abs_diff : int -> (int -> int)
 ```
 
@@ -820,14 +820,14 @@ Labeled arguments are useful in a few different cases:
   Boolean flag, which indicates whether that array will ever shrink when
   elements are removed.
 
-```ocaml file=examples/htable_sig1.ml
+```ocaml skip
 val create_hashtable : int -> bool -> ('a,'b) Hashtable.t
 ```
 
 The signature makes it hard to divine the meaning of those two arguments.
   but with labeled arguments, we can make the intent immediately clear.
 
-```ocaml file=examples/htable_sig2.ml
+```ocaml skip
 val create_hashtable :
   init_size:int -> allow_shrinking:bool -> ('a,'b) Hashtable.t
 ```
@@ -841,7 +841,7 @@ Choosing label names well is especially important for Boolean values, since
   the same type. For example, consider this signature for a function that
   extracts a substring.
 
-```ocaml file=examples/substring_sig1.ml
+```ocaml skip
 val substring: string -> int -> int -> string
 ```
 
@@ -849,7 +849,7 @@ Here, the two `ints` are the starting position and length of the substring
   to extract, respectively, but you wouldn't know that from the type
   signature. We can make the signature more informative by adding labels.
 
-```ocaml file=examples/substring_sig2.ml
+```ocaml skip
 val substring: string -> pos:int -> len:int -> string
 ```
 
@@ -1085,7 +1085,7 @@ Even worse, it would be perfectly consistent for `f` to take an optional
 argument instead of a labeled one, which could lead to this type signature
 for `numeric_deriv`.
 
-```ocaml file=examples/numerical_deriv_alt_sig.mli
+```ocaml skip
 val numeric_deriv :
   delta:float ->
   x:float -> y:float -> f:(?x:float -> y:float -> float) -> float * float

--- a/book/variables-and-functions/dune
+++ b/book/variables-and-functions/dune
@@ -5,5 +5,3 @@
   mdx
   ppx_jane)
  (preludes prelude.ml))
-
-(data_only_dirs examples)

--- a/book/variables-and-functions/examples/abs_diff.mli
+++ b/book/variables-and-functions/examples/abs_diff.mli
@@ -1,1 +1,0 @@
-val abs_diff : int -> (int -> int)

--- a/book/variables-and-functions/examples/htable_sig1.ml
+++ b/book/variables-and-functions/examples/htable_sig1.ml
@@ -1,1 +1,0 @@
-val create_hashtable : int -> bool -> ('a,'b) Hashtable.t

--- a/book/variables-and-functions/examples/htable_sig2.ml
+++ b/book/variables-and-functions/examples/htable_sig2.ml
@@ -1,2 +1,0 @@
-val create_hashtable :
-  init_size:int -> allow_shrinking:bool -> ('a,'b) Hashtable.t

--- a/book/variables-and-functions/examples/numerical_deriv_alt_sig.mli
+++ b/book/variables-and-functions/examples/numerical_deriv_alt_sig.mli
@@ -1,3 +1,0 @@
-val numeric_deriv :
-  delta:float ->
-  x:float -> y:float -> f:(?x:float -> y:float -> float) -> float * float

--- a/book/variables-and-functions/examples/substring_sig1.ml
+++ b/book/variables-and-functions/examples/substring_sig1.ml
@@ -1,1 +1,0 @@
-val substring: string -> int -> int -> string

--- a/book/variables-and-functions/examples/substring_sig2.ml
+++ b/book/variables-and-functions/examples/substring_sig2.ml
@@ -1,1 +1,0 @@
-val substring: string -> pos:int -> len:int -> string


### PR DESCRIPTION
This removes unecessary examples form the chapter and replaces them by unchecked blocks.

This is strictly equivalent since the examples weren't checked either given they're comprised of single mli files.

In the future we'd like to have native support for checking interfaces in MDX.