### PR TITLE
Use acc and hd in List.fold example

### DIFF
--- a/book/lists-and-patterns/README.md
+++ b/book/lists-and-patterns/README.md
@@ -409,7 +409,7 @@ can for example use `fold` to reverse a list, in which case the accumulator
 is itself a list:
 
 ```ocaml env=main
-# List.fold ~init:[] ~f:(fun list x -> x :: list) [1;2;3;4]
+# List.fold ~init:[] ~f:(fun acc hd -> hd :: acc) [1;2;3;4]
 - : int list = [4; 3; 2; 1]
 ```
 


### PR DESCRIPTION
More meaningful than the names used, and fits the pattern used in the rest of the chapter.  Alternative solution to: #3284 