### PR TITLE
Add a non-deterministic dune profile to run mdx non-det tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 	dune runtest
 
 test-all:
-	dune build @runtest-all
+	dune runtest --profile non-deterministic
 
 dep:
 	dune exec -- rwo-dep

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ make promote
 ### Testing non-deterministic examples
 
 A few code examples are not deterministic: for instance benchmarks. In this case,
-there is a special command to run:
+there is a specific dune profile to use:
 
 ```
-make test-all
+dune runtest --profile non-deterministic ...
 ```
 
 To accept the changes:

--- a/dune
+++ b/dune
@@ -1,0 +1,2 @@
+(env
+ (non-deterministic (env-vars (MDX_RUN_NON_DETERMINISTIC true))))


### PR DESCRIPTION
Closes #3135.

This PR adds a non-deterministic dune profile that allows running the non-deterministic mdx tests. It also updates the non-deterministic tests README section!