### PR TITLE
Added function call example "Guided Tour"

### DIFF
--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -77,6 +77,8 @@ Now let's try a few simple numerical calculations:
 - : int = 100
 # 3 * 5 > 14
 - : bool = true
+# Float.max 2.7182 3.1415
+- : float = 3.1415
 ```
 
 By and large, this is pretty similar to what you'd find in any programming


### PR DESCRIPTION
The description in the "OCaml as a Calculator" section explains that function arguments are separated by spaces instead of by parentheses and commas, but the example does not include a case that demonstrates this.

This PR adds an example of using the `Float.max` function on two numbers.