### PR TITLE
Add missing commas

### DIFF
--- a/book/prologue/README.md
+++ b/book/prologue/README.md
@@ -245,8 +245,8 @@ on Windows and Javascript. The examples in Part I of the book will only use
 support]{.idx}
 
 This book is not intended as a reference manual. We aim to teach you about
-the language and about libraries tools and techniques that will help you be a
-more effective OCaml programmer. But it's no replacement for API
+the language, as well as libraries, tools, and techniques that will help you be
+a more effective OCaml programmer. But it's no replacement for API
 documentation or the OCaml manual and man pages. You can find documentation
 for all of the libraries and tools referenced in the book
 [online](https://ocaml.janestreet.com/ocaml-core/).


### PR DESCRIPTION
Hi there,

Thanks for the great book! I added some commas where they were needed:

> libraries tools and techniques

but also made a judgement call and suggested ", as well as" instead of the first "and". If you'd like, let me know and I can change that back to ", and".

Thanks!
Brian