### PR TITLE
Replace = with Yojson.Basic.equal in read_json example

### DIFF
--- a/book/json/examples/read_json/read_json.ml
+++ b/book/json/examples/read_json/read_json.ml
@@ -8,4 +8,4 @@ let () =
   (* Use the file JSON constructor *)
   let json2 = Yojson.Basic.from_file "book.json" in
   (* Test that the two values are the same *)
-  print_endline (if json1 = json2 then "OK" else "FAIL")
+  print_endline (if Yojson.Basic.equal json1 json2 then "OK" else "FAIL")


### PR DESCRIPTION
Core hides polymorphic equal by default, so without this change the example does not compile.

~~I'm new to OCaml, so I'm not sure if poly compare worked with an older version of Core (seems unlikely).~~ It looks like Core began hiding polymorphic compare [around 2019](https://discuss.ocaml.org/t/removing-polymorphic-compare-from-core/2994). I have Core v0.13.0 and before this change the example failed to compile with this error message:

```
File "read_json.ml", line 11, characters 20-25:
11 |   print_endline (if json1 = json2 then "OK" else "FAIL")
                         ^^^^^
Error: This expression has type Yojson.Basic.t
       but an expression was expected of type int
```