### PR TITLE
Eliminate some type throwback

### DIFF
--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -907,8 +907,7 @@ types. Here's a toy example of a data type representing a point in
 two-dimensional space:[datatypes/defining new]{.idx}
 
 ```ocaml env=main
-# type point2d = { x : float; y : float }
-type point2d = { x : float; y : float; }
+type point2d = { x : float; y : float }
 ```
 
 `point2d` is a *record* type, which you can think of as a tuple where the
@@ -955,12 +954,9 @@ types. Here, for example, are some types for modeling different geometric
 objects that contain values of type `point2d`:
 
 ```ocaml env=main
-# type circle_desc  = { center: point2d; radius: float }
-type circle_desc = { center : point2d; radius : float; }
-# type rect_desc    = { lower_left: point2d; width: float; height: float }
-type rect_desc = { lower_left : point2d; width : float; height : float; }
-# type segment_desc = { endpoint1: point2d; endpoint2: point2d }
-type segment_desc = { endpoint1 : point2d; endpoint2 : point2d; }
+type circle_desc  = { center: point2d; radius: float }
+type rect_desc    = { lower_left: point2d; width: float; height: float }
+type segment_desc = { endpoint1: point2d; endpoint2: point2d }
 ```
 
 Now, imagine that you want to combine multiple objects of these types
@@ -970,13 +966,9 @@ this is using a *variant* type:[datatypes/variant types]{.idx}[variant
 types/combining multiple object types with]{.idx}
 
 ```ocaml env=main
-# type scene_element =
-    | Circle  of circle_desc
-    | Rect    of rect_desc
-    | Segment of segment_desc
 type scene_element =
-    Circle of circle_desc
-  | Rect of rect_desc
+  | Circle  of circle_desc
+  | Rect    of rect_desc
   | Segment of segment_desc
 ```
 
@@ -1104,16 +1096,11 @@ numbers.[imperative programming/mutable record fields]{.idx}[mutable record
 fields]{.idx}[data structures/mutable record fields]{.idx}
 
 ```ocaml env=main
-# type running_sum =
-    { mutable sum: float;
-      mutable sum_sq: float; (* sum of squares *)
-      mutable samples: int;
-    }
-type running_sum = {
-  mutable sum : float;
-  mutable sum_sq : float;
-  mutable samples : int;
-}
+type running_sum =
+  { mutable sum: float;
+    mutable sum_sq: float; (* sum of squares *)
+    mutable samples: int;
+  }
 ```
 
 The fields in `running_sum` are designed to be easy to extend incrementally,

--- a/book/records/README.md
+++ b/book/records/README.md
@@ -89,8 +89,7 @@ this regard. As an example, here's a type that represents an arbitrary
 item tagged with a line number.
 
 ```ocaml env=main
-# type 'a with_line_num = { item: 'a; line_num: int }
-type 'a with_line_num = { item : 'a; line_num : int; }
+type 'a with_line_num = { item: 'a; line_num: int }
 ```
 
 We can then write polymorphic functions that operate over this

--- a/book/records/README.md
+++ b/book/records/README.md
@@ -417,55 +417,29 @@ it is standard practice to name the type associated with the module
 `t`. Using this style we would write:
 
 ```ocaml env=main
-# module Log_entry = struct
-    type t =
-      { session_id: string;
-        time: Time_ns.t;
-        important: bool;
-        message: string;
-      }
-  end
-  module Heartbeat = struct
-    type t =
-      { session_id: string;
-        time: Time_ns.t;
-        status_message: string;
-      }
-  end
-  module Logon = struct
-    type t =
-      { session_id: string;
-        time: Time_ns.t;
-        user: string;
-        credentials: string;
-      }
-  end
-module Log_entry :
-  sig
-    type t = {
-      session_id : string;
-      time : Time_ns.t;
-      important : bool;
-      message : string;
+module Log_entry = struct
+  type t =
+    { session_id: string;
+      time: Time_ns.t;
+      important: bool;
+      message: string;
     }
-  end
-module Heartbeat :
-  sig
-    type t = {
-      session_id : string;
-      time : Time_ns.t;
-      status_message : string;
+end
+module Heartbeat = struct
+  type t =
+    { session_id: string;
+      time: Time_ns.t;
+      status_message: string;
     }
-  end
-module Logon :
-  sig
-    type t = {
-      session_id : string;
-      time : Time_ns.t;
-      user : string;
-      credentials : string;
+end
+module Logon = struct
+  type t =
+    { session_id: string;
+      time: Time_ns.t;
+      user: string;
+      credentials: string;
     }
-  end
+end
 ```
 
 Now, our log-entry-creation function can be rendered as follows:

--- a/book/records/README.md
+++ b/book/records/README.md
@@ -31,13 +31,12 @@ name for protocols such as FTP or SSH. Note that we're going to open
 API, which you need `Core` for.
 
 ```ocaml env=main
-# open Core
-# type service_info =
-    { service_name : string;
-      port         : int;
-      protocol     : string;
-    }
-type service_info = { service_name : string; port : int; protocol : string; }
+open Core
+type service_info =
+  { service_name : string;
+    port         : int;
+    protocol     : string;
+  }
 ```
 
 We can construct a `service_info` just as easily as we declared its
@@ -51,7 +50,8 @@ language you can use for parsing a string.
 # #require "re"
 # let service_info_of_string line =
     let matches =
-      Re.exec (Re.Posix.compile_pat "([a-zA-Z]+)[ \t]+([0-9]+)/([a-zA-Z]+)") line
+      let pat = "([a-zA-Z]+)[ \t]+([0-9]+)/([a-zA-Z]+)" in
+      Re.exec (Re.Posix.compile_pat pat) line
     in
     { service_name = Re.Group.get matches 1;
       port = Int.of_string (Re.Group.get matches 2);
@@ -171,18 +171,12 @@ record so that it preserves comments. We can do this by providing a
 new definition of `service_info` that includes a `comment` field:
 
 ```ocaml env=main
-# type service_info =
-    { service_name : string;
-      port         : int;
-      protocol     : string;
-      comment      : string option;
-    }
-type service_info = {
-  service_name : string;
-  port : int;
-  protocol : string;
-  comment : string option;
-}
+type service_info =
+  { service_name : string;
+    port         : int;
+    protocol     : string;
+    comment      : string option;
+  }
 ```
 
 The code for `service_info_to_string` would continue to compile
@@ -354,40 +348,23 @@ and connected. All of these messages include a session ID and the time
 the message was generated.
 
 ```ocaml env=main
-# type log_entry =
-    { session_id: string;
-      time: Time_ns.t;
-      important: bool;
-      message: string;
-    }
-  type heartbeat =
-    { session_id: string;
-      time: Time_ns.t;
-      status_message: string;
-    }
-  type logon =
-    { session_id: string;
-      time: Time_ns.t;
-      user: string;
-      credentials: string;
-    }
-type log_entry = {
-  session_id : string;
-  time : Time_ns.t;
-  important : bool;
-  message : string;
-}
-type heartbeat = {
-  session_id : string;
-  time : Time_ns.t;
-  status_message : string;
-}
-type logon = {
-  session_id : string;
-  time : Time_ns.t;
-  user : string;
-  credentials : string;
-}
+type log_entry =
+  { session_id: string;
+    time: Time_ns.t;
+    important: bool;
+    message: string;
+  }
+type heartbeat =
+  { session_id: string;
+    time: Time_ns.t;
+    status_message: string;
+  }
+type logon =
+  { session_id: string;
+    time: Time_ns.t;
+    user: string;
+    credentials: string;
+  }
 ```
 
 Reusing field names can lead to some ambiguity. For example, if we
@@ -589,26 +566,24 @@ Fairly often, you will find yourself wanting to create a new record
 that differs from an existing record in only a subset of the
 fields. For example, imagine our logging server had a record type for
 representing the state of a given client, including when the last
-heartbeat was received from that client. The following defines a type
-for representing this information, as well as a function for updating
-the client information when a new heartbeat arrives:[functional
-updates]{.idx}[records/functional updates to]{.idx}
+heartbeat was received from that client.
+[functional updates]{.idx}
+[records/functional updates to]{.idx}
 
 ```ocaml env=main
-# type client_info =
-    { addr: Unix.Inet_addr.t;
-      port: int;
-      user: string;
-      credentials: string;
-      last_heartbeat_time: Time_ns.t;
-  }
-type client_info = {
-  addr : Unix.inet_addr;
-  port : int;
-  user : string;
-  credentials : string;
-  last_heartbeat_time : Time_ns.t;
+type client_info =
+  { addr: Unix.Inet_addr.t;
+    port: int;
+    user: string;
+    credentials: string;
+    last_heartbeat_time: Time_ns.t;
 }
+```
+
+We could define a function for updating the client information when a
+new heartbeat arrives as follows.
+
+```ocaml env=main
 # let register_heartbeat t hb =
     { addr = t.addr;
       port = t.port;
@@ -651,21 +626,13 @@ accommodate the new fields. Consider what happens if we decided to add
 a field for the status message received on the last heartbeat:
 
 ```ocaml env=main
-# type client_info =
-    { addr: Unix.Inet_addr.t;
-      port: int;
-      user: string;
-      credentials: string;
-      last_heartbeat_time: Time_ns.t;
-      last_heartbeat_status: string;
-  }
-type client_info = {
-  addr : Unix.inet_addr;
-  port : int;
-  user : string;
-  credentials : string;
-  last_heartbeat_time : Time_ns.t;
-  last_heartbeat_status : string;
+type client_info =
+  { addr: Unix.Inet_addr.t;
+    port: int;
+    user: string;
+    credentials: string;
+    last_heartbeat_time: Time_ns.t;
+    last_heartbeat_status: string;
 }
 ```
 
@@ -692,21 +659,13 @@ code, we've made the last two fields of `client_info` mutable:[mutable
 record fields]{.idx}[records/mutable fields in]{.idx}
 
 ```ocaml env=main
-# type client_info =
-    { addr: Unix.Inet_addr.t;
-      port: int;
-      user: string;
-      credentials: string;
-      mutable last_heartbeat_time: Time_ns.t;
-      mutable last_heartbeat_status: string;
-  }
-type client_info = {
-  addr : Unix.inet_addr;
-  port : int;
-  user : string;
-  credentials : string;
-  mutable last_heartbeat_time : Time_ns.t;
-  mutable last_heartbeat_status : string;
+type client_info =
+  { addr: Unix.Inet_addr.t;
+    port: int;
+    user: string;
+    credentials: string;
+    mutable last_heartbeat_time: Time_ns.t;
+    mutable last_heartbeat_status: string;
 }
 ```
 

--- a/book/variants/README.md
+++ b/book/variants/README.md
@@ -33,27 +33,25 @@ declared as a simple tag, with pipes used to separate the different
 cases. Note that variant tags must be capitalized.
 
 ```ocaml env=main
-# open Base
-# open Stdio
-# type basic_color =
-  | Black | Red | Green | Yellow | Blue | Magenta | Cyan | White
+open Base
+open Stdio
 type basic_color =
-    Black
-  | Red
-  | Green
-  | Yellow
-  | Blue
-  | Magenta
-  | Cyan
-  | White
+  | Black | Red | Green | Yellow | Blue | Magenta | Cyan | White
+```
+
+As we show below, the variant tags introduced by the definition of
+`basic_color` can be used for constructing values of that type.
+
+```ocaml env=main
 # Cyan
 - : basic_color = Cyan
 # [Blue; Magenta; Red]
 - : basic_color list = [Blue; Magenta; Red]
 ```
 
-There's an integer code associated with each basic color, and thex
-following function uses pattern matching to express that function.
+The following function uses pattern matching to convert each of these
+to the corresponding integer code that is used for communicating these
+colors to the terminal.
 
 ```ocaml env=main
 # let basic_color_to_int = function
@@ -64,8 +62,8 @@ val basic_color_to_int : basic_color -> int = <fun>
 - : int list = [4; 1]
 ```
 
-We know that the above function is complete, because the compiler
-would have warned us if we'd missed a color.
+We know that the above function handles every color in `basic_color`
+because the compiler would have warned us if we'd missed one:
 
 ```ocaml env=main
 # let incomplete_color_to_int = function
@@ -78,7 +76,7 @@ val incomplete_color_to_int : basic_color -> int = <fun>
 ```
 
 In any case, using the correct function, we can generate escape codes
-to change the color of a given string displayed in a terminal:
+to change the color of a given string displayed in a terminal.
 
 ```ocaml env=main
 # let color_by_number number text =
@@ -112,27 +110,28 @@ up into the following groups:
 We'll also represent this more complicated color space as a variant,
 but this time, the different tags will have arguments that describe
 the data available in each case. Note that variants can have multiple
-arguments, which are separated by `*`s:
+arguments, which are separated by `*`s.
 
 ```ocaml env=main
-# type weight = Regular | Bold
 type weight = Regular | Bold
-# type color =
-    | Basic of basic_color * weight (* basic colors, regular and bold *)
-    | RGB   of int * int * int      (* 6x6x6 color cube *)
-    | Gray  of int                  (* 24 grayscale levels *)
 type color =
-    Basic of basic_color * weight
-  | RGB of int * int * int
-  | Gray of int
+  | Basic of basic_color * weight (* basic colors, regular and bold *)
+  | RGB   of int * int * int      (* 6x6x6 color cube *)
+  | Gray  of int                  (* 24 grayscale levels *)
+```
+
+As before, we can use these introduced tags to construct values of our
+newly defined type.
+
+```ocaml env=main
 # [RGB (250,70,70); Basic (Green, Regular)]
 - : color list = [RGB (250, 70, 70); Basic (Green, Regular)]
 ```
 
-Once again, we'll use pattern matching to convert a color to a
-corresponding integer. But in this case, the pattern matching does
-more than separate out the different cases; it also allows us to
-extract the data associated with each tag:
+And again, we'll use pattern matching to convert a color to a
+corresponding integer.  In this case, the pattern matching does more
+than separate out the different cases; it also allows us to extract
+the data associated with each tag:
 
 ```ocaml env=main
 # let color_to_int = function
@@ -255,16 +254,11 @@ Consider what would happen if we were to change the definition of
 `color` to the following:
 
 ```ocaml env=main
-# type color =
-    | Basic of basic_color     (* basic colors *)
-    | Bold  of basic_color     (* bold basic colors *)
-    | RGB   of int * int * int (* 6x6x6 color cube *)
-    | Gray  of int             (* 24 grayscale levels *)
 type color =
-    Basic of basic_color
-  | Bold of basic_color
-  | RGB of int * int * int
-  | Gray of int
+  | Basic of basic_color     (* basic colors *)
+  | Bold  of basic_color     (* bold basic colors *)
+  | RGB   of int * int * int (* 6x6x6 color cube *)
+  | Gray  of int             (* 24 grayscale levels *)
 ```
 
 We've essentially broken out the `Basic` case into two cases, `Basic` and
@@ -440,13 +434,9 @@ be any of these three types.  The `client_message` type below lets you
 do just that.
 
 ```ocaml env=main
-# type client_message = | Logon of Logon.t
-                        | Heartbeat of Heartbeat.t
-                        | Log_entry of Log_entry.t
-type client_message =
-    Logon of Logon.t
-  | Heartbeat of Heartbeat.t
-  | Log_entry of Log_entry.t
+type client_message = | Logon of Logon.t
+                      | Heartbeat of Heartbeat.t
+                      | Log_entry of Log_entry.t
 ```
 
 In particular, a `client_message` is a `Logon` *or* a `Heartbeat` *or*
@@ -535,12 +525,8 @@ module Logon : sig type t = { user : string; credentials : string; } end
 We can then define a variant type that combines these types:
 
 ```ocaml env=main
-# type details =
-    | Logon of Logon.t
-    | Heartbeat of Heartbeat.t
-    | Log_entry of Log_entry.t
 type details =
-    Logon of Logon.t
+  | Logon of Logon.t
   | Heartbeat of Heartbeat.t
   | Log_entry of Log_entry.t
 ```
@@ -613,14 +599,10 @@ the variant, then OCaml allows us to embed the records directly into
 the variant.
 
 ```ocaml env=main
-# type details =
-    | Logon     of { user: string; credentials: string; }
-    | Heartbeat of { status_message: string; }
-    | Log_entry of { important: bool; message: string; }
 type details =
-    Logon of { user : string; credentials : string; }
-  | Heartbeat of { status_message : string; }
-  | Log_entry of { important : bool; message : string; }
+  | Logon     of { user: string; credentials: string; }
+  | Heartbeat of { status_message: string; }
+  | Log_entry of { important: bool; message: string; }
 ```
 
 Even though the type is different, we can write `messages_for_user` in
@@ -679,18 +661,12 @@ An expression in this language will be defined by the variant `expr`, with
 one tag for each kind of expression we want to support:
 
 ```ocaml env=main
-# type 'a expr =
-    | Base  of 'a
-    | Const of bool
-    | And   of 'a expr list
-    | Or    of 'a expr list
-    | Not   of 'a expr
 type 'a expr =
-    Base of 'a
+  | Base  of 'a
   | Const of bool
-  | And of 'a expr list
-  | Or of 'a expr list
-  | Not of 'a expr
+  | And   of 'a expr list
+  | Or    of 'a expr list
+  | Not   of 'a expr
 ```
 
 Note that the definition of the type `expr` is recursive, meaning that a
@@ -709,11 +685,9 @@ language for an email processor, your base predicates might specify the tests
 you would run against an email, as in the following example:
 
 ```ocaml env=main
-# type mail_field = To | From | CC | Date | Subject
 type mail_field = To | From | CC | Date | Subject
-# type mail_predicate = { field: mail_field;
-                          contains: string }
-type mail_predicate = { field : mail_field; contains : string; }
+type mail_predicate = { field: mail_field;
+                        contains: string }
 ```
 
 Using the preceding code, we can construct a simple expression with
@@ -1034,16 +1008,11 @@ follows, using an ordinary variant:
 [polymorphic variant types/vs. ordinary variants]{.idx}
 
 ```ocaml env=main
-# type extended_color =
-    | Basic of basic_color * weight  (* basic colors, regular and bold *)
-    | RGB   of int * int * int       (* 6x6x6 color space *)
-    | Gray  of int                   (* 24 grayscale levels *)
-    | RGBA  of int * int * int * int (* 6x6x6x6 color space *)
 type extended_color =
-    Basic of basic_color * weight
-  | RGB of int * int * int
-  | Gray of int
-  | RGBA of int * int * int * int
+  | Basic of basic_color * weight  (* basic colors, regular and bold *)
+  | RGB   of int * int * int       (* 6x6x6 color space *)
+  | Gray  of int                   (* 24 grayscale levels *)
+  | RGBA  of int * int * int * int (* 6x6x6x6 color space *)
 ```
 
 We want to write a function `extended_color_to_int`, that works like

--- a/book/variants/README.md
+++ b/book/variants/README.md
@@ -365,25 +365,15 @@ can achieve with this by reiterating the `Log_entry` message type that
 was described in [Records](records.html#records){data-type=xref}.
 
 ```ocaml env=main
-# module Time_ns = Core_kernel.Time_ns
 module Time_ns = Core_kernel.Time_ns
-# module Log_entry = struct
-    type t =
-      { session_id: string;
-        time: Time_ns.t;
-        important: bool;
-        message: string;
-      }
-  end
-module Log_entry :
-  sig
-    type t = {
-      session_id : string;
-      time : Time_ns.t;
-      important : bool;
-      message : string;
+module Log_entry = struct
+  type t =
+    { session_id: string;
+      time: Time_ns.t;
+      important: bool;
+      message: string;
     }
-  end
+end
 ```
 
 This record type combines multiple pieces of data into a single value.
@@ -395,38 +385,21 @@ To construct an example of where this is useful, we'll first write out
 the other message types that came along-side `Log_entry`.
 
 ```ocaml env=main
-# module Heartbeat = struct
-    type t =
-      { session_id: string;
-        time: Time_ns.t;
-        status_message: string;
-      }
-  end
-  module Logon = struct
-    type t =
-      { session_id: string;
-        time: Time_ns.t;
-        user: string;
-        credentials: string;
-      }
-  end
-module Heartbeat :
-  sig
-    type t = {
-      session_id : string;
-      time : Time_ns.t;
-      status_message : string;
+module Heartbeat = struct
+  type t =
+    { session_id: string;
+      time: Time_ns.t;
+      status_message: string;
     }
-  end
-module Logon :
-  sig
-    type t = {
-      session_id : string;
-      time : Time_ns.t;
-      user : string;
-      credentials : string;
+end
+module Logon = struct
+  type t =
+    { session_id: string;
+      time: Time_ns.t;
+      user: string;
+      credentials: string;
     }
-  end
+end
 ```
 
 A variant comes in handy when we want to represent values that could
@@ -504,22 +477,19 @@ first step is to cut down the definitions of each per-message record
 to contain just the information unique to that record:
 
 ```ocaml env=main
-# module Log_entry = struct
-    type t = { important: bool;
-               message: string;
-             }
-  end
-  module Heartbeat = struct
-    type t = { status_message: string; }
-  end
-  module Logon = struct
-    type t = { user: string;
-               credentials: string;
-             }
-  end
-module Log_entry : sig type t = { important : bool; message : string; } end
-module Heartbeat : sig type t = { status_message : string; } end
-module Logon : sig type t = { user : string; credentials : string; } end
+module Log_entry = struct
+  type t = { important: bool;
+             message: string;
+           }
+end
+module Heartbeat = struct
+  type t = { status_message: string; }
+end
+module Logon = struct
+  type t = { user: string;
+             credentials: string;
+           }
+end
 ```
 
 We can then define a variant type that combines these types:
@@ -535,12 +505,11 @@ Separately, we need a record that contains the fields that are common across
 all messages:
 
 ```ocaml env=main
-# module Common = struct
-    type t = { session_id: string;
-               time: Time_ns.t;
-             }
-  end
-module Common : sig type t = { session_id : string; time : Time_ns.t; } end
+module Common = struct
+  type t = { session_id: string;
+             time: Time_ns.t;
+           }
+end
 ```
 
 A full message can then be represented as a pair of a `Common.t` and a


### PR DESCRIPTION
Used the MDX feature where you can write down snippets of OCaml without getting toplevel style type-throwback.  This eliminates some annoying duplication of types. 

Then end result seems clearly easier to read, but it's a little bit odd to change the presentation so that somethings look like they're in a toplevel session and some don't, while to follow along, the reader would need to do it all in a toplevel session.