### PR TITLE
Unused endpoint1 and endpoint2 in Segment case

### DIFF
--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -991,7 +991,7 @@ tell *utop* to process the input, not to separate two declarations
     | Rect { lower_left; width; height } ->
       point.x    > lower_left.x && point.x < lower_left.x + width
       && point.y > lower_left.y && point.y < lower_left.y + height
-    | _ -> false
+    | Segment _ -> false
 
   let is_inside_scene point scene =
     List.exists scene

--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -991,7 +991,7 @@ tell *utop* to process the input, not to separate two declarations
     | Rect { lower_left; width; height } ->
       point.x    > lower_left.x && point.x < lower_left.x + width
       && point.y > lower_left.y && point.y < lower_left.y + height
-    | Segment { endpoint1; endpoint2 } -> false
+    | _ -> false
 
   let is_inside_scene point scene =
     List.exists scene


### PR DESCRIPTION
matching case `Segment { endpoint1; endpoint2 }` and returning false raises compilation warnings/errors for unused variables.  
Using _ makes Segment definition quite idle but not it compiles fine.