### PR TITLE
Fix handling of WIP chapters

### DIFF
--- a/bin/bin/app.ml
+++ b/bin/bin/app.ml
@@ -57,9 +57,10 @@ let build_chapter : Command.t =
       let repo_root = Params.repo_root
       and out_dir = Params.out_dir
       and file = Params.file
+      and include_wip = Params.include_wip
       in
       fun () ->
-        Book.make ~repo_root ~out_dir (`Chapter file) ]
+        Book.make ~repo_root ~include_wip ~out_dir (`Chapter file) ]
 
 let build_frontpage : Command.t =
   Command.async ~summary:"build frontpage"

--- a/bin/lib/rules.ml
+++ b/bin/lib/rules.ml
@@ -16,17 +16,19 @@ let print_web ~repo_root ~include_wip =
     ~f:(fun chapter ->
         let html_file = book_folder / (chapter.name ^ ".html") in
         let target = chapter.name ^ ".html" in
+        let include_wip = if include_wip then "-include-wip " else "" in
         Writer.writef out
           {|
 (rule
  (alias %s)
  (target %s)
  (deps (alias %s) %s)
- (action (run rwo-build build chapter -o . -repo-root %s %%{dep:%s})))
+ (action (run rwo-build build chapter -o . -repo-root %s %s%%{dep:%s})))
 |}
           alias
           target
           html_alias
           toc_file
           repo_root
+          include_wip
           html_file)

--- a/bin/lib/toc.mli
+++ b/bin/lib/toc.mli
@@ -18,7 +18,7 @@ module Repr : sig
 
   type t = [ `part of part | `chapter of chapter] list [@@deriving sexp]
 
-  val get : ?repo_root: string -> unit -> t Deferred.t
+  val get : ?repo_root: string -> include_wip: bool -> unit -> t Deferred.t
 
   val get_chapters :
     ?repo_root: string -> include_wip: bool -> unit -> chapter list Deferred.t
@@ -53,7 +53,7 @@ type part = {
 
 type t = part list
 
-val get : ?repo_root:string -> unit -> t Deferred.t
+val get : ?repo_root:string -> include_wip: bool -> unit -> t Deferred.t
 val of_chapters : chapter list -> part list
 
 (** Return all chapter numbers and names, ordered by chapter

--- a/static-wip/dune.inc
+++ b/static-wip/dune.inc
@@ -3,154 +3,154 @@
  (alias site-wip)
  (target classes.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/classes.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/classes.html})))
 
 (rule
  (alias site-wip)
  (target command-line-parsing.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/command-line-parsing.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/command-line-parsing.html})))
 
 (rule
  (alias site-wip)
  (target compiler-backend.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/compiler-backend.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/compiler-backend.html})))
 
 (rule
  (alias site-wip)
  (target compiler-frontend.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/compiler-frontend.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/compiler-frontend.html})))
 
 (rule
  (alias site-wip)
  (target concurrent-programming.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/concurrent-programming.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/concurrent-programming.html})))
 
 (rule
  (alias site-wip)
  (target data-serialization.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/data-serialization.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/data-serialization.html})))
 
 (rule
  (alias site-wip)
  (target error-handling.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/error-handling.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/error-handling.html})))
 
 (rule
  (alias site-wip)
  (target files-modules-and-programs.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/files-modules-and-programs.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/files-modules-and-programs.html})))
 
 (rule
  (alias site-wip)
  (target first-class-modules.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/first-class-modules.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/first-class-modules.html})))
 
 (rule
  (alias site-wip)
  (target foreign-function-interface.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/foreign-function-interface.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/foreign-function-interface.html})))
 
 (rule
  (alias site-wip)
  (target functors.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/functors.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/functors.html})))
 
 (rule
  (alias site-wip)
  (target garbage-collector.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/garbage-collector.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/garbage-collector.html})))
 
 (rule
  (alias site-wip)
  (target guided-tour.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/guided-tour.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/guided-tour.html})))
 
 (rule
  (alias site-wip)
  (target imperative-programming.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/imperative-programming.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/imperative-programming.html})))
 
 (rule
  (alias site-wip)
  (target json.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/json.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/json.html})))
 
 (rule
  (alias site-wip)
  (target lists-and-patterns.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/lists-and-patterns.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/lists-and-patterns.html})))
 
 (rule
  (alias site-wip)
  (target maps-and-hashtables.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/maps-and-hashtables.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/maps-and-hashtables.html})))
 
 (rule
  (alias site-wip)
  (target objects.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/objects.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/objects.html})))
 
 (rule
  (alias site-wip)
  (target parsing-with-ocamllex-and-menhir.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/parsing-with-ocamllex-and-menhir.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/parsing-with-ocamllex-and-menhir.html})))
 
 (rule
  (alias site-wip)
  (target ppx.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/ppx.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/ppx.html})))
 
 (rule
  (alias site-wip)
  (target prologue.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/prologue.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/prologue.html})))
 
 (rule
  (alias site-wip)
  (target records.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/records.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/records.html})))
 
 (rule
  (alias site-wip)
  (target runtime-memory-layout.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/runtime-memory-layout.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/runtime-memory-layout.html})))
 
 (rule
  (alias site-wip)
  (target testing.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/testing.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/testing.html})))
 
 (rule
  (alias site-wip)
  (target variables-and-functions.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/variables-and-functions.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/variables-and-functions.html})))
 
 (rule
  (alias site-wip)
  (target variants.html)
  (deps (alias ../book/html) ../book/toc.scm)
- (action (run rwo-build build chapter -o . -repo-root .. %{dep:../book/variants.html})))
+ (action (run rwo-build build chapter -o . -repo-root .. -include-wip %{dep:../book/variants.html})))


### PR DESCRIPTION
Fixes #3376

Chapter numbering was incorrect in the generated website and any chapter preceding a wip chapter contained a dead link to it instead of a link to the next non wip chapter. This is fixed by always filtering the table of content early.