### PR TITLE
Fix online list docs broken link

### DIFF
--- a/book/lists-and-patterns/README.md
+++ b/book/lists-and-patterns/README.md
@@ -525,7 +525,7 @@ val render_table : string list -> string list list -> string = <fun>
 
 The previous example we worked through touched on only three of the functions
 in `List`. We won't cover the entire interface (for that you should look at
-the [online docs](http://realworldocaml.org/doc)), but a few more functions
+the [online docs](https://ocaml.janestreet.com/ocaml-core/latest/doc/base/Base/List/index.html)), but a few more functions
 are useful enough to mention here.
 
 #### Combining list elements with List.reduce


### PR DESCRIPTION
The "online docs" link in the [`More useful list functions`](https://dev.realworldocaml.org/lists-and-patterns.html#more-useful-list-functions) of the `Lists and patterns` chapter leads to a [broken link](http://realworldocaml.org/doc). 

Technically, it should lead to: https://ocaml.janestreet.com/ocaml-core/latest/doc/, but since the section is on the `List` functions from `Base`, I believe it should lead to: https://ocaml.janestreet.com/ocaml-core/latest/doc/base/Base/List/index.html