### PR TITLE
WIP - PDF utop code formatting more consistent with HTML

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -83,6 +83,7 @@
   autogobble,
   columns=fullflexible,
   showspaces=false,
+  keepspaces=true,
   showtabs=false,
   breaklines=true,
   showstringspaces=false,


### PR DESCRIPTION
EDIT - I realized that this breaks multi-line comment syntax highlighting. Will fix

This change makes PDF code formatting more consistent with HTML code formatting in 2 ways:
1. All lines in a top-level utop expression are prefixed with `#`. Previously, only the first line was prefixed with `#`.
2. All top-level utop expressions will end with `;;`. If the top-level expression is a single line, then the double semicolon will appear in the same line as the expression. If the top-level expression is multi-line, then the double semicolon will be appended on a new line.

Photos that illustrate updated formatting:

Single line:
* Previous PDF
![PrevPdf2](https://user-images.githubusercontent.com/1217056/97307631-521f0f80-1836-11eb-8026-ac836bcf1486.png)
* New PDF
![NewPdf2](https://user-images.githubusercontent.com/1217056/97307646-56e3c380-1836-11eb-97ec-366b7c3ebd22.png)
* Current HTML
![CurrHtml2](https://user-images.githubusercontent.com/1217056/97307656-5a774a80-1836-11eb-9c4c-b13692062037.png)

Multi line:
* Previous PDF
![PrevPdf](https://user-images.githubusercontent.com/1217056/97307306-e6d53d80-1835-11eb-9c71-653cf83de856.png)
* New PDF
![NewPdf](https://user-images.githubusercontent.com/1217056/97307355-f5235980-1835-11eb-81b9-d4da3019ae2d.png)
* Current HTML
![CurrHtml](https://user-images.githubusercontent.com/1217056/97307373-fbb1d100-1835-11eb-8df0-8bfc16ef491b.png)

Fixes #3275 

I originally noticed this discrepancy after reading text that hinted that a double-semicolon might be missing: https://github.com/realworldocaml/book/blame/master/book/guided-tour/README.md#L818

An annoying part about code formatting in the PDF is that, unlike the HTML, a user cannot select top-level utop expressions without also selecting the `#` characters. I wonder if there is a way to configure the `listings` package so that mouse selection behaves more like the HTML.