### PR TITLE
Update README.md

### DIFF
--- a/book/maps-and-hashtables/examples/correct/core_comparable.ml
+++ b/book/maps-and-hashtables/examples/correct/core_comparable.ml
@@ -1,0 +1,20 @@
+open Core
+
+module Book = struct
+  module T = struct
+    type t = { title: string; isbn: string }
+    [@@deriving compare, sexp]
+  end
+  include T
+  include Comparable.Make(T)
+end
+
+let title_set = Set.empty (module String)
+
+let add_title title_set (book : Book.t) =
+  let open Book in
+  Set.add title_set book.title
+
+(* 
+Error: This expression has type string but an expression was expected of type t
+ *)


### PR DESCRIPTION
The difference between `Base.Comparator` and `Core.Comparator` is not well-documented.
The silent shadowing is confusing sometimes due to the unclear error message.
I am thinking many people like me use this book as the document and tutorial for Base and Core.
Therefore, I suggest mentioning this in this section though the book may focus on Base.
In fact, even the official document contains errors on `sexp_of` ([link to doc](https://ocaml.janestreet.com/ocaml-core/latest/doc/core_kernel/Core_kernel/Map/index.html) and [my pull to fix there](https://github.com/janestreet/core_kernel/pull/102))