### PR TITLE
Example rules: pick dune in PATH

### DIFF
--- a/bin/examples-rules/examples_rules.ml
+++ b/bin/examples-rules/examples_rules.ml
@@ -43,7 +43,7 @@ let print_rule ~dir_name ~path (config : Config.t) =
  (deps
   (source_tree %s)%s)
  (action
-  (run dune build @all @runtest --root %s)))
+  (system "dune build @all @runtest --root %s")))
 
 (alias
  (name runtest)

--- a/book/command-line-parsing/examples/dune.inc
+++ b/book/command-line-parsing/examples/dune.inc
@@ -5,7 +5,7 @@
   (source_tree ./correct/cal_add_days)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/cal_add_days)))
+  (system "dune build @all @runtest --root ./correct/cal_add_days")))
 
 (alias
  (name runtest)
@@ -18,7 +18,7 @@
   (package core)
   (package ppx_jane))
  (action
-  (run dune build @all @runtest --root ./correct/cal_add_interactive)))
+  (system "dune build @all @runtest --root ./correct/cal_add_interactive")))
 
 (alias
  (name runtest)
@@ -30,7 +30,7 @@
   (source_tree ./correct/cal_add_interactive2)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/cal_add_interactive2)))
+  (system "dune build @all @runtest --root ./correct/cal_add_interactive2")))
 
 (alias
  (name runtest)
@@ -42,7 +42,7 @@
   (source_tree ./correct/cal_add_sub_days)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/cal_add_sub_days)))
+  (system "dune build @all @runtest --root ./correct/cal_add_sub_days")))
 
 (alias
  (name runtest)
@@ -54,7 +54,7 @@
   (source_tree ./correct/md5)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/md5)))
+  (system "dune build @all @runtest --root ./correct/md5")))
 
 (alias
  (name runtest)
@@ -66,7 +66,7 @@
   (source_tree ./correct/md5_as_filename)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/md5_as_filename)))
+  (system "dune build @all @runtest --root ./correct/md5_as_filename")))
 
 (alias
  (name runtest)
@@ -78,7 +78,7 @@
   (source_tree ./correct/md5_let_syntax)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/md5_let_syntax)))
+  (system "dune build @all @runtest --root ./correct/md5_let_syntax")))
 
 (alias
  (name runtest)
@@ -90,7 +90,7 @@
   (source_tree ./correct/md5_let_syntax2)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/md5_let_syntax2)))
+  (system "dune build @all @runtest --root ./correct/md5_let_syntax2")))
 
 (alias
  (name runtest)
@@ -102,7 +102,7 @@
   (source_tree ./correct/md5_multiarg)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/md5_multiarg)))
+  (system "dune build @all @runtest --root ./correct/md5_multiarg")))
 
 (alias
  (name runtest)
@@ -114,7 +114,7 @@
   (source_tree ./correct/md5_sequence)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/md5_sequence)))
+  (system "dune build @all @runtest --root ./correct/md5_sequence")))
 
 (alias
  (name runtest)
@@ -126,7 +126,7 @@
   (source_tree ./correct/md5_succinct)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/md5_succinct)))
+  (system "dune build @all @runtest --root ./correct/md5_succinct")))
 
 (alias
  (name runtest)
@@ -138,7 +138,7 @@
   (source_tree ./correct/md5_with_custom_arg)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/md5_with_custom_arg)))
+  (system "dune build @all @runtest --root ./correct/md5_with_custom_arg")))
 
 (alias
  (name runtest)
@@ -150,7 +150,7 @@
   (source_tree ./correct/md5_with_default_file)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/md5_with_default_file)))
+  (system "dune build @all @runtest --root ./correct/md5_with_default_file")))
 
 (alias
  (name runtest)
@@ -162,7 +162,7 @@
   (source_tree ./correct/md5_with_flags)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/md5_with_flags)))
+  (system "dune build @all @runtest --root ./correct/md5_with_flags")))
 
 (alias
  (name runtest)
@@ -174,7 +174,7 @@
   (source_tree ./correct/md5_with_optional_file)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/md5_with_optional_file)))
+  (system "dune build @all @runtest --root ./correct/md5_with_optional_file")))
 
 (alias
  (name runtest)

--- a/book/concurrent-programming/examples/dune.inc
+++ b/book/concurrent-programming/examples/dune.inc
@@ -6,7 +6,7 @@
   (package core)
   (package async))
  (action
-  (run dune build @all @runtest --root ./correct/better_echo)))
+  (system "dune build @all @runtest --root ./correct/better_echo")))
 
 (alias
  (name runtest)
@@ -19,7 +19,7 @@
   (package core)
   (package async))
  (action
-  (run dune build @all @runtest --root ./correct/echo)))
+  (system "dune build @all @runtest --root ./correct/echo")))
 
 (alias
  (name runtest)
@@ -32,7 +32,7 @@
   (package core)
   (package async))
  (action
-  (run dune build @all @runtest --root ./correct/native_code_log_delays)))
+  (system "dune build @all @runtest --root ./correct/native_code_log_delays")))
 
 (alias
  (name runtest)
@@ -48,7 +48,7 @@
   (package yojson)
   (package textwrap))
  (action
-  (run dune build @all @runtest --root ./correct/search)))
+  (system "dune build @all @runtest --root ./correct/search")))
 
 (alias
  (name runtest)
@@ -64,7 +64,7 @@
   (package yojson)
   (package textwrap))
  (action
-  (run dune build @all @runtest --root ./correct/search_out_of_order)))
+  (system "dune build @all @runtest --root ./correct/search_out_of_order")))
 
 (alias
  (name runtest)
@@ -78,7 +78,7 @@
   (package yojson)
   (package textwrap))
  (action
-  (run dune build @all @runtest --root ./correct/search_with_configurable_server)))
+  (system "dune build @all @runtest --root ./correct/search_with_configurable_server")))
 
 (alias
  (name runtest)
@@ -92,7 +92,7 @@
   (package yojson)
   (package textwrap))
  (action
-  (run dune build @all @runtest --root ./correct/search_with_error_handling)))
+  (system "dune build @all @runtest --root ./correct/search_with_error_handling")))
 
 (alias
  (name runtest)
@@ -108,7 +108,7 @@
   (package yojson)
   (package textwrap))
  (action
-  (run dune build @all @runtest --root ./correct/search_with_timeout)))
+  (system "dune build @all @runtest --root ./correct/search_with_timeout")))
 
 (alias
  (name runtest)
@@ -122,7 +122,7 @@
   (package yojson)
   (package textwrap))
  (action
-  (run dune build @all @runtest --root ./correct/search_with_timeout_no_leak)))
+  (system "dune build @all @runtest --root ./correct/search_with_timeout_no_leak")))
 
 (alias
  (name runtest)
@@ -136,7 +136,7 @@
   (package yojson)
   (package textwrap))
  (action
-  (run dune build @all @runtest --root ./correct/search_with_timeout_no_leak_simple)))
+  (system "dune build @all @runtest --root ./correct/search_with_timeout_no_leak_simple")))
 
 (alias
  (name runtest)

--- a/book/data-serialization/examples/dune.inc
+++ b/book/data-serialization/examples/dune.inc
@@ -5,7 +5,7 @@
   (source_tree ./correct/int_interval_manual_sexp)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/int_interval_manual_sexp)))
+  (system "dune build @all @runtest --root ./correct/int_interval_manual_sexp")))
 
 (alias
  (name runtest)
@@ -17,7 +17,7 @@
   (source_tree ./correct/int_interval_nosexp)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/int_interval_nosexp)))
+  (system "dune build @all @runtest --root ./correct/int_interval_nosexp")))
 
 (alias
  (name runtest)
@@ -29,7 +29,7 @@
   (source_tree ./correct/int_interval_sexp_override)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/int_interval_sexp_override)))
+  (system "dune build @all @runtest --root ./correct/int_interval_sexp_override")))
 
 (alias
  (name runtest)
@@ -42,7 +42,7 @@
   (package core)
   (package sexplib))
  (action
-  (run dune build @all @runtest --root ./correct/read_foo)))
+  (system "dune build @all @runtest --root ./correct/read_foo")))
 
 (alias
  (name runtest)
@@ -55,7 +55,7 @@
   (package core)
   (package sexplib))
  (action
-  (run dune build @all @runtest --root ./correct/read_foo_better_errors)))
+  (system "dune build @all @runtest --root ./correct/read_foo_better_errors")))
 
 (alias
  (name runtest)
@@ -67,7 +67,7 @@
   (source_tree ./correct/sexp)
   (package base))
  (action
-  (run dune build @all @runtest --root ./correct/sexp)))
+  (system "dune build @all @runtest --root ./correct/sexp")))
 
 (alias
  (name runtest)
@@ -80,7 +80,7 @@
   (package core)
   (package sexplib))
  (action
-  (run dune build @all @runtest --root ./correct/test_interval)))
+  (system "dune build @all @runtest --root ./correct/test_interval")))
 
 (alias
  (name runtest)

--- a/book/error-handling/examples/dune.inc
+++ b/book/error-handling/examples/dune.inc
@@ -6,7 +6,7 @@
   (package base)
   (package stdio))
  (action
-  (run dune build @all @runtest --root ./correct/blow_up)))
+  (system "dune build @all @runtest --root ./correct/blow_up")))
 
 (alias
  (name runtest)
@@ -19,7 +19,7 @@
   (package core)
   (package core_bench))
  (action
-  (run dune build @all @runtest --root ./correct/exn_cost)))
+  (system "dune build @all @runtest --root ./correct/exn_cost")))
 
 (alias
  (name runtest)

--- a/book/files-modules-and-programs/examples/dune.inc
+++ b/book/files-modules-and-programs/examples/dune.inc
@@ -5,7 +5,7 @@
   (source_tree ./correct/abstract-username)
   (package base))
  (action
-  (run dune build @all @runtest --root ./correct/abstract-username)))
+  (system "dune build @all @runtest --root ./correct/abstract-username")))
 
 (alias
  (name runtest)
@@ -17,7 +17,7 @@
   (source_tree ./correct/ext-option)
   (package base))
  (action
-  (run dune build @all @runtest --root ./correct/ext-option)))
+  (system "dune build @all @runtest --root ./correct/ext-option")))
 
 (alias
  (name runtest)
@@ -30,7 +30,7 @@
   (package base)
   (package stdio))
  (action
-  (run dune build @all @runtest --root ./correct/freq-dune)))
+  (system "dune build @all @runtest --root ./correct/freq-dune")))
 
 (alias
  (name runtest)
@@ -43,7 +43,7 @@
   (package base)
   (package stdio))
  (action
-  (run dune build @all @runtest --root ./correct/freq-fast)))
+  (system "dune build @all @runtest --root ./correct/freq-fast")))
 
 (alias
  (name runtest)
@@ -56,7 +56,7 @@
   (package base)
   (package stdio))
  (action
-  (run dune build @all @runtest --root ./correct/freq-median)))
+  (system "dune build @all @runtest --root ./correct/freq-median")))
 
 (alias
  (name runtest)
@@ -69,7 +69,7 @@
   (package base)
   (package stdio))
  (action
-  (run dune build @all @runtest --root ./correct/freq-with-counter)))
+  (system "dune build @all @runtest --root ./correct/freq-with-counter")))
 
 (alias
  (name runtest)
@@ -82,7 +82,7 @@
   (package base)
   (package stdio))
  (action
-  (run dune build @all @runtest --root ./correct/freq-with-sig)))
+  (system "dune build @all @runtest --root ./correct/freq-with-sig")))
 
 (alias
  (name runtest)
@@ -95,7 +95,7 @@
   (package base)
   (package stdio))
  (action
-  (run dune build @all @runtest --root ./correct/freq-with-sig-abstract-fixed)))
+  (system "dune build @all @runtest --root ./correct/freq-with-sig-abstract-fixed")))
 
 (alias
  (name runtest)

--- a/book/guided-tour/examples/dune.inc
+++ b/book/guided-tour/examples/dune.inc
@@ -6,7 +6,7 @@
   (package base)
   (package stdio))
  (action
-  (run dune build @all @runtest --root ./correct/sum)))
+  (system "dune build @all @runtest --root ./correct/sum")))
 
 (alias
  (name runtest)

--- a/book/imperative-programming/examples/dune.inc
+++ b/book/imperative-programming/examples/dune.inc
@@ -7,7 +7,7 @@
   (package core)
   (package ppx_jane))
  (action
-  (run dune build @all @runtest --root ./correct/dictionary)))
+  (system "dune build @all @runtest --root ./correct/dictionary")))
 
 (alias
  (name runtest)
@@ -19,7 +19,7 @@
   (source_tree ./correct/dlist)
   (package base))
  (action
-  (run dune build @all @runtest --root ./correct/dlist)))
+  (system "dune build @all @runtest --root ./correct/dlist")))
 
 (alias
  (name runtest)
@@ -31,7 +31,7 @@
   (source_tree ./correct/time_converter)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/time_converter)))
+  (system "dune build @all @runtest --root ./correct/time_converter")))
 
 (alias
  (name runtest)
@@ -43,7 +43,7 @@
   (source_tree ./correct/time_converter2)
   (package core))
  (action
-  (run dune build @all @runtest --root ./correct/time_converter2)))
+  (system "dune build @all @runtest --root ./correct/time_converter2")))
 
 (alias
  (name runtest)

--- a/book/maps-and-hashtables/examples/dune.inc
+++ b/book/maps-and-hashtables/examples/dune.inc
@@ -6,7 +6,7 @@
   (package base)
   (package stdio))
  (action
-  (run dune build @all @runtest --root ./correct/freq-fast)))
+  (system "dune build @all @runtest --root ./correct/freq-fast")))
 
 (alias
  (name runtest)
@@ -19,7 +19,7 @@
   (package base)
   (package core_bench))
  (action
-  (run dune build @all @runtest --root ./correct/map_vs_hash)))
+  (system "dune build @all @runtest --root ./correct/map_vs_hash")))
 
 (alias
  (name runtest)
@@ -31,7 +31,7 @@
   (source_tree ./correct/map_vs_hash2)
   (package core_bench))
  (action
-  (run dune build @all @runtest --root ./correct/map_vs_hash2)))
+  (system "dune build @all @runtest --root ./correct/map_vs_hash2")))
 
 (alias
  (name runtest)

--- a/book/testing/examples/dune.inc
+++ b/book/testing/examples/dune.inc
@@ -8,7 +8,7 @@
   (package ppx_jane)
   (package stdio))
  (action
-  (run dune build @all @runtest --root ./correct/bigger_quickcheck_test)))
+  (system "dune build @all @runtest --root ./correct/bigger_quickcheck_test")))
 
 (alias
  (name runtest)
@@ -23,7 +23,7 @@
   (package ppx_jane)
   (package stdio))
  (action
-  (run dune build @all @runtest --root ./correct/bigger_quickcheck_test_with_ppx)))
+  (system "dune build @all @runtest --root ./correct/bigger_quickcheck_test_with_ppx")))
 
 (alias
  (name runtest)
@@ -39,7 +39,7 @@
   (package stdio)
   (package typerep))
  (action
-  (run dune build @all @runtest --root ./correct/manual_property_test)))
+  (system "dune build @all @runtest --root ./correct/manual_property_test")))
 
 (alias
  (name runtest)
@@ -53,7 +53,7 @@
   (package ppx_jane)
   (package stdio))
  (action
-  (run dune build @all @runtest --root ./correct/multi_block_expect_test)))
+  (system "dune build @all @runtest --root ./correct/multi_block_expect_test")))
 
 (alias
  (name runtest)
@@ -69,7 +69,7 @@
   (package stdio)
   (package typerep))
  (action
-  (run dune build @all @runtest --root ./correct/simple_expect_test)))
+  (system "dune build @all @runtest --root ./correct/simple_expect_test")))
 
 (alias
  (name runtest)
@@ -85,7 +85,7 @@
   (package stdio)
   (package typerep))
  (action
-  (run dune build @all @runtest --root ./correct/simple_inline_test)))
+  (system "dune build @all @runtest --root ./correct/simple_inline_test")))
 
 (alias
  (name runtest)
@@ -103,7 +103,7 @@
   (package typerep)
   (package uri))
  (action
-  (run dune build @all @runtest --root ./correct/soup_test_fixed)))
+  (system "dune build @all @runtest --root ./correct/soup_test_fixed")))
 
 (alias
  (name runtest)
@@ -119,7 +119,7 @@
   (package stdio)
   (package typerep))
  (action
-  (run dune build @all @runtest --root ./correct/trivial_expect_test_fixed)))
+  (system "dune build @all @runtest --root ./correct/trivial_expect_test_fixed")))
 
 (alias
  (name runtest)

--- a/book/variants/examples/dune.inc
+++ b/book/variants/examples/dune.inc
@@ -5,7 +5,7 @@
   (source_tree ./correct/variants-termcol)
   (package base))
  (action
-  (run dune build @all @runtest --root ./correct/variants-termcol)))
+  (system "dune build @all @runtest --root ./correct/variants-termcol")))
 
 (alias
  (name runtest)
@@ -16,7 +16,7 @@
  (deps
   (source_tree ./correct/variants-termcol-fixed))
  (action
-  (run dune build @all @runtest --root ./correct/variants-termcol-fixed)))
+  (system "dune build @all @runtest --root ./correct/variants-termcol-fixed")))
 
 (alias
  (name runtest)


### PR DESCRIPTION
Previously, example rules would invoke dune using `(run dune ...)`.

When seeing `(run prog ...)`, dune first looks for a public executable named `prog` in the workspace before looking at the environment (`PATH`).

In the case of this repository, it happens that a dune executable is in the workspace, because the sources of dune-build-info are there and they are the same as the dune sources.

When building the examples, this dune (2.6 at the moment) will be picked, and it will try to read dune-package files for the other packages. If these have been written by a dune in the environment with a higher version, it will fail with an error. Effectively, this puts a constraint that dune in the environment should be older than the vendored one.

To fix this, the `(run dune ...)` action is replaced by `(system "dune ...")`. This is treated as an opaque string passed to the system shell, which resolves using the environment only. This causes the vendored dune to be ignored.

Thanks @NathanReb for the idea!