### PR TITLE
Fix typos in lists-and-patterns.

### DIFF
--- a/book/lists-and-patterns/README.md
+++ b/book/lists-and-patterns/README.md
@@ -581,9 +581,10 @@ drops all elements for which `None` is returned.
 
 Here's an example. The following function computes a list of file extensions
 from a list of files, piping the results through `List.dedup_and_sort` to
-return the list with duplicates removed and in sorted order. Note that
-this example uses `String.rsplit2` from the String module to split astring on the
-rightmost appearance of a given character:[lists/duplicate removal]{.idx}[duplicates, removing]{.idx}
+return the list with duplicates removed and in sorted order. Note that this
+example uses `String.rsplit2` from the String module to split a string on the
+rightmost appearance of a given character:[lists/duplicate
+removal]{.idx}[duplicates, removing]{.idx}
 
 ```ocaml env=main
 # let extensions filenames =
@@ -934,8 +935,8 @@ corresponds to the expected numerical comparison functions. For strings, it's
 a lexicographic comparison.
 
 That said, experienced OCaml developers typically avoid polymorphic
-comparison. That's surprising, given how obviously useful is, but there's a
-good reason. While it's very convenient, in some cases, the type oblivious
+comparison. That's surprising, given how obviously useful it is, but there's
+a good reason. While it's very convenient, in some cases, the type oblivious
 nature of polymorphic compare means that it does something that doesn't make
 sense for the particular type of values you're dealing with. This can lead to
 surprising and hard to resolve bugs in your code. It's for this reason that


### PR DESCRIPTION
There are few minor typos I've encountered while going through the chapter 3. Thank you for the great book and making it available for everyone!

I've formatted the diff using line width = 77 which I inferred by looking at the rest of the text, let me know if there's an official way of formatting the md files.

The changes are `s/astring/a string/` and `s/useful is/useful it is/`, but the diff is larger due to reformatting.