### PR TITLE
Fix references to Imperative Programming chapter.

### DIFF
--- a/book/concurrent-programming/README.md
+++ b/book/concurrent-programming/README.md
@@ -709,7 +709,7 @@ val w : '_weak4 Pipe.Writer.t = <abstr>
 
 `r` and `w` are really just read and write handles to the same underlying
 object. Note that `r` and `w` have weakly polymorphic types, as discussed in
-[Imperative Programming](guided-tour.html#imperative-programming){data-type=xref},
+[Imperative Programming](imperative-programming.html#imperative-programming-1){data-type=xref},
 and so can only contain values of a single, yet-to-be-determined type.
 
 If we just try and write to the writer, we'll see that we block indefinitely

--- a/book/maps-and-hashtables/README.md
+++ b/book/maps-and-hashtables/README.md
@@ -794,7 +794,7 @@ Error: This expression has type
 
 Hash tables are the imperative cousin of maps. We walked over a basic hash
 table implementation in
-[Imperative Programming 1](imperative-programming.html#imperative-programming-1){data-type=xref},
+[Imperative Programming](imperative-programming.html#imperative-programming-1){data-type=xref},
 so in this section we'll mostly discuss the pragmatics of Core's `Hashtbl`
 module. We'll cover this material more briefly than we did with maps because
 many of the concepts are shared. [hash tables/basics of]{.idx}

--- a/book/records/README.md
+++ b/book/records/README.md
@@ -660,8 +660,7 @@ mutable ones, are specified when the record is created.
 OCaml's policy of immutable-by-default is a good one, but imperative
 programming is an important part of programming in OCaml. We go into
 more depth about how (and when) to use OCaml's imperative features in
-[Imperative
-Programming](guided-tour.html#imperative-programming){data-type=xref}.
+[Imperative Programming](imperative-programming.html#imperative-programming-1){data-type=xref}.
 
 ## First-Class Fields
 

--- a/book/variables-and-functions/README.md
+++ b/book/variables-and-functions/README.md
@@ -435,7 +435,7 @@ A function is *recursive* if it refers to itself in its definition. Recursion
 is important in any programming language, but is particularly important in
 functional languages, because it is the way that you build looping
 constructs. (As will be discussed in more detail in
-[Imperative Programming 1](imperative-programming.html#imperative-programming-1){data-type=xref},
+[Imperative Programming](imperative-programming.html#imperative-programming-1){data-type=xref},
 OCaml also supports imperative looping constructs like `for` and `while`, but
 these are only useful when using OCaml's imperative features.)[recursive
 functions/definition of]{.idx}[functions/recursive functions]{.idx}


### PR DESCRIPTION
References in two places were linking to the guided tour while it's
clear from the context that they should link to the dedicated chapter
about imperative programming.

References in two other places were titled "Imperative Programming 1",
in contrast with the rest titled simply "Imperative Programming".