### PR TITLE
include images in PDFs

### DIFF
--- a/book/book.yml
+++ b/book/book.yml
@@ -17,5 +17,11 @@ lot: true
 author:
 - Yaron Minsky
 - Anil Madhavapeddy
+pandoc-latex-environment:
+  noteblock: [note]
+  tipblock: [tip]
+  warningblock: [warning]
+  cautionblock: [caution]
+  importantblock: [important]
 ---
 

--- a/book/compiler-frontend/README.md
+++ b/book/compiler-frontend/README.md
@@ -50,10 +50,9 @@ archive that can be reused by other applications.[compilation units]{.idx}
 The overall compilation pipeline looks like this: [compilation
 process/diagram of]{.idx}
 
-<figure style="float: 0">
-  <img src="images/front-end/pipeline.png"/>
-</figure>
-
+\
+![](images/front-end/pipeline.png "Compilation pipeline")
+\
 
 Notice that the pipeline branches toward the end. OCaml has multiple compiler
 backends that reuse the early stages of compilation but produce very

--- a/book/cup-template.tex
+++ b/book/cup-template.tex
@@ -32,6 +32,21 @@
 \usepackage{newtxtext}
 \usepackage{newtxmath}
 \usepackage{graphicx}
+\makeatletter
+\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+\makeatother
+% Scale images if necessary, so that they will not overflow the page
+% margins by default, and it is still possible to overwrite the defaults
+% using explicit options in \includegraphics[width, height, ...]{}
+\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+% Set default figure placement to htbp
+\makeatletter
+\def\fps@figure{htbp}
+\makeatother
+
+\usepackage{float}
+\floatplacement{figure}{H}
 
 \usepackage{csquotes}
 

--- a/book/garbage-collector/README.md
+++ b/book/garbage-collector/README.md
@@ -106,10 +106,9 @@ The minor heap is a contiguous chunk of virtual memory that is usually a few
 megabytes in size so that it can be scanned quickly. [minor heaps/allocating
 on]{.idx}
 
-<figure style="float: 0">
-  <img src="images/gc/minor_heap.png"/>
-</figure>
-
+\
+![](images/gc/minor_heap.png "Minor GC heap")
+\
 
 The runtime stores the boundaries of the minor heap in two pointers that
 delimit the start and end of the heap region (`caml_young_start` and

--- a/book/imperative-programming/README.md
+++ b/book/imperative-programming/README.md
@@ -906,17 +906,15 @@ val edit_distance : string -> string -> int = <fun>
 The thing to note is that if you call `edit_distance "OCaml" "ocaml"`,
 then that will in turn dispatch the following calls:
 
-<figure style="float: 0">
-  <img src="images/imperative-programming/edit_distance.png"/>
-</figure>
-
+\
+![](images/imperative-programming/edit_distance.png "Edit distance")
+\
 
 And these calls will in turn dispatch other calls:
 
-<figure style="float: 0">
-  <img src="images/imperative-programming/edit_distance2.png"/>
-</figure>
-
+\
+![](images/imperative-programming/edit_distance2.png "Edit distance two")
+\
 
 As you can see, some of these calls are repeats. For example, there
 are two different calls to `edit_distance "OCam" "oca"`. The number of

--- a/book/lists-and-patterns/README.md
+++ b/book/lists-and-patterns/README.md
@@ -48,10 +48,9 @@ figure below is a rough graphical representation of how the list
 `1 :: 2 :: 3 :: []` is laid out as a data structure. The final arrow (from
 the box containing `3`) points to the empty list.[lists/structure of]{.idx}
 
-<figure style="float: 0">
-  <img src="images/lists-and-patterns/lists_layout.png"/>
-</figure>
-
+\
+![](images/lists-and-patterns/lists_layout.png "Lists layout")
+\
 
 Each `::` essentially adds a new block to the proceding picture. Such a block
 contains two things: a reference to the data in that list element, and a

--- a/book/runtime-memory-layout/README.md
+++ b/book/runtime-memory-layout/README.md
@@ -179,10 +179,9 @@ values. The GC always inspects fields and follows them as part of the
 collection process described earlier. [garbage collection/opaque bytes
 and]{.idx}[opaque bytes]{.idx}
 
-<figure style="float: 0">
-  <img src="images/memory-repr/block.png"/>
-</figure>
-
+\
+ ![Memory representation of a block](images/memory-repr/block.png "Memory representation of a block")
+\
 
 The `size` field records the length of the block in memory words. This is 22
 bits on 32-bit platforms, which is the reason OCaml strings are limited to 16
@@ -234,9 +233,9 @@ integers.
 
 ## Tuples, Records, and Arrays
 
-<figure style="float: 0">
-  <img src="images/memory-repr/tuple_layout.png"/>
-</figure>
+\
+![](images/memory-repr/tuple_layout.png "Tuple Layout")
+\
 
 
 Tuples, records, and arrays are all represented identically at runtime as a
@@ -285,10 +284,10 @@ integers. OCaml therefore special-cases records or arrays that contain
 packed directly in the data section, with `Double_array_tag` set to signal to
 the collector that the contents are not OCaml values.
 
-<figure style="float: 0">
-  <img src="images/memory-repr/float_array_layout.png"/>
-</figure>
 
+\
+![](images/memory-repr/float_array_layout.png "Float array layout")
+\
 
 First, let's check that float arrays do in fact have a different tag number
 from normal floating-point values:
@@ -465,10 +464,9 @@ collector. The block contents are the contents of the string, with padding
 bytes to align the block on a word boundary. [strings/memory representation
 of]{.idx}[runtime memory representation/string values]{.idx}
 
-<figure style="float: 0">
-  <img src="images/memory-repr/string_block.png"/>
-</figure>
-
+\
+![](images/memory-repr/string_block.png "String block layout")
+\
 
 On a 32-bit machine, the padding is calculated based on the modulo of the
 string length and word size to ensure the result is word-aligned. A 64-bit
@@ -484,10 +482,9 @@ This string representation is a clever way to ensure that the contents are
 always zero-terminated by the padding word and to still compute its length
 efficiently without scanning the whole string. The following formula is used:
 
-<figure style="float: 0">
-  <img src="images/memory-repr/string_size_calc.png"/>
-</figure>
-
+\
+![](images/memory-repr/string_size_calc.png "String size calculation")
+\
 
 The guaranteed `NULL` termination comes in handy when passing a string to C,
 but is not relied upon to compute the length from OCaml code. OCaml strings
@@ -570,4 +567,3 @@ mathematical Fortran libraries. These allow developers to write
 high-performance numerical code for applications that require linear algebra.
 It supports large vectors and matrices, but with static typing safety of
 OCaml to make it easier to write safe algorithms.
-<a data-type="indexterm" data-startref="MAPocaml">&nbsp;</a><a data-type="indexterm" data-startref="VALmemory">&nbsp;</a>

--- a/static-wip/dune
+++ b/static-wip/dune
@@ -18,7 +18,7 @@
 (rule
  (alias pdf-wip)
  (targets book.pdf)
- (deps book.tex)
+ (deps book.tex (alias site-wip-content))
  (action
    (progn
      (system "xelatex book.tex")
@@ -29,7 +29,7 @@
 ; Website Generation
 
 (alias
-  (name site-wip)
+  (name site-wip-content)
   (deps css/app.css
         css/prism.css
         images/anil.jpg
@@ -67,7 +67,7 @@
 (rule
  (alias site-wip)
  (targets index.html)
- (deps (alias ../book/html) ../book/index.html ../book/toc.scm)
+ (deps (alias ../book/html) ../book/index.html ../book/toc.scm (alias site-wip-content))
  (action (run rwo-build build index -include-wip -o . -repo-root ..)))
 
 (rule

--- a/static/dune
+++ b/static/dune
@@ -18,7 +18,7 @@
 (rule
  (alias pdf)
  (targets book.pdf)
- (deps book.tex)
+ (deps book.tex (alias site-content))
  (action
    (progn
      (system "xelatex book.tex")
@@ -29,7 +29,7 @@
 ; Website Generation
 
 (alias
-  (name site)
+  (name site-content)
   (deps CNAME
         css/app.css
         css/prism.css
@@ -68,7 +68,7 @@
 (rule
  (alias site)
  (targets index.html)
- (deps (alias ../book/html) ../book/index.html ../book/toc.scm)
+ (deps (alias ../book/html) ../book/index.html ../book/toc.scm (alias site-content))
  (action (run rwo-build build index -o . -repo-root ..)))
 
 (rule


### PR DESCRIPTION
Use markdown format for pandoc rather than the HTML, and setup
the appropriate latex figure magic