### PR TITLE
Add callouts to pdf

### DIFF
--- a/bin/pandoc-rwo/README.md
+++ b/bin/pandoc-rwo/README.md
@@ -1,0 +1,4 @@
+Pandoc.ml[i] are included from the Pandoc library,
+with patches: https://github.com/smimram/ocaml-pandoc/pull/2
+
+License: LGPLv2

--- a/bin/pandoc-rwo/dune
+++ b/bin/pandoc-rwo/dune
@@ -1,0 +1,5 @@
+(executable
+  (public_name pandoc-rwo)
+  (name pandoc_rwo)
+  (libraries yojson)
+)

--- a/bin/pandoc-rwo/pandoc.ml
+++ b/bin/pandoc-rwo/pandoc.ml
@@ -1,0 +1,391 @@
+open Yojson.Basic
+open Util
+
+(* http://hackage.haskell.org/package/pandoc-types-1.19/docs/Text-Pandoc-Definition.html *)
+
+type format = string
+
+(** Attributes: identifier, classes, key/values. *)
+type attr = string * string list * (string * string) list
+
+(** Target: url, title. *)
+type target = string * string
+
+type list_number_style = DefaultStyle | Example | Decimal | LowerRoman | UpperRoman | LowerAlpha | UpperAlpha
+
+type list_number_delim = DefaultDelim | Period | OneParen | TwoParensPeriod
+
+type list_attributes = int * list_number_style * list_number_delim
+
+type math_type = DisplayMath | InlineMath
+
+type quote_type = DoubleQuote | SingleQuote
+
+type inline =
+  | Code of attr * string
+  | Emph of inline list
+  | Image of attr * inline list * target
+  | Link of attr * inline list * target
+  (* | Math of math_type * string *)
+  (* | Note of block list *)
+  | Quoted of quote_type * inline list
+  | RawInline of string * string
+  (* | SoftBreak *)
+  | Space
+  | SmallCaps of inline list
+  | Str of string
+  | UnhandledInline of Yojson.Basic.t
+
+and block =
+  | BulletList of block list list
+  | CodeBlock of attr * string
+  | Header of int * attr * inline list
+  | OrderedList of list_attributes * block list list
+  | Para of inline list
+  | Plain of inline list
+  | RawBlock of format * string
+  | Div of attr * block list
+  | UnhandledBlock of Yojson.Basic.t
+
+type t = { api_version : int list; meta : Yojson.Basic.t; blocks : block list }
+
+module JSON = struct
+  let element_type e =
+    Util.to_string (List.assoc "t" (to_assoc e))
+
+  let element_contents e =
+    List.assoc "c" (to_assoc e)
+
+  let to_pair p =
+    match Util.to_list p with
+    | [x; y] -> x, y
+    | _ -> assert false
+
+  let to_triple p =
+    match Util.to_list p with
+    | [x; y; z] -> x, y, z
+    | _ -> assert false
+
+  let to_attr attr =
+    let id, classes, keyvals = to_triple attr in
+    let id = Util.to_string id in
+    let classes = List.map Util.to_string (Util.to_list classes) in
+    let keyvals = List.map Util.to_list (Util.to_list keyvals) in
+    let keyvals = List.map (function [k;v] -> (Util.to_string k, Util.to_string v) | _ -> assert false) keyvals in
+    id, classes, keyvals
+
+  let to_target t =
+    let url, title = to_pair t in
+    Util.to_string url, Util.to_string title
+
+  let to_list_attributes a =
+    let n, ns, nd = to_triple a in
+    let n = Util.to_int n in
+    let ns =
+      match element_type ns with
+      | "DefaultStyle" -> DefaultStyle
+      | "Example" -> Example
+      | "Decimal" -> Decimal
+      | "LowerRoman" -> LowerRoman
+      | "UpperRoman" -> UpperRoman
+      | "LowerAlpha" -> LowerAlpha
+      | "UpperAlpha" -> UpperAlpha
+      | _ -> assert false
+    in
+    let nd =
+      match element_type nd with
+      | "DefaultDelim" -> DefaultDelim
+      | "Period" -> Period
+      | "OneParen" -> OneParen
+      | "TwoParensPeriod" -> TwoParensPeriod
+      | _ -> assert false
+      in
+    n, ns, nd
+
+  (* let to_math_type t = *)
+    (* match element_type t with *)
+    (* | "DisplayMath" -> DisplayMath *)
+    (* | "InlineMath" -> InlineMath *)
+    (* | _ -> assert false *)
+
+  let rec to_inline e =
+    match element_type e with
+    | "Code" ->
+       let a, c = to_pair (element_contents e) in
+       let a = to_attr a in
+       let c = Util.to_string c in
+       Code (a, c)
+    | "Emph" -> Emph (List.map to_inline (Util.to_list (element_contents e)))
+    | "Image" ->
+       let a, i, t = to_triple (element_contents e) in
+       let a = to_attr a in
+       let i = List.map to_inline (Util.to_list i) in
+       let t = to_target t in
+       Image (a, i, t)
+    | "Link" ->
+       let a, i, t = to_triple (element_contents e) in
+       let a = to_attr a in
+       let i = List.map to_inline (Util.to_list i) in
+       let t = to_target t in
+       Link (a, i, t)
+    (* | "Math" -> *)
+       (* let t, m = to_pair (element_contents e) in *)
+       (* let t = to_math_type t in *)
+       (* let m = Util.to_string m in *)
+       (* Math (t, m) *)
+    (* | "Note" -> Note (List.map to_block (Util.to_list (element_contents e))) *)
+    | "Quoted" ->
+       let q, l = to_pair (element_contents e) in
+       let q =
+         match element_type q with
+         | "DoubleQuote" -> DoubleQuote
+         | "SingleQuote" -> SingleQuote
+         | q -> failwith ("Unhandled quote type "^q)
+       in
+       let l = List.map to_inline (Util.to_list l) in
+       Quoted (q, l)
+    | "SmallCaps" -> SmallCaps (List.map to_inline (Util.to_list (element_contents e)))
+    (* | "SoftBreak" -> SoftBreak *)
+    | "Str" -> Str (Util.to_string (element_contents e))
+    | "Space" -> Space
+    | _ -> UnhandledInline e
+      
+  and to_block e =
+    match element_type e with
+    | "BulletList" ->
+       let l = Util.to_list (element_contents e) in
+       let l = List.map (fun l -> List.map to_block (Util.to_list l)) l in
+       BulletList l
+    | "CodeBlock" ->
+       let attr, code = to_pair (element_contents e) in
+       CodeBlock (to_attr attr, Util.to_string code)
+    | "Header" ->
+       let n, a, t = to_triple (element_contents e) in
+       let n = Util.to_int n in
+       let a = to_attr a in
+       let t = List.map to_inline (Util.to_list t) in
+       Header (n, a, t)
+    | "OrderedList" ->
+       let la, l = to_pair (element_contents e) in
+       let la = to_list_attributes la in
+       let l = Util.to_list l in
+       let l = List.map (fun l -> List.map to_block (Util.to_list l)) l in
+       OrderedList (la, l)
+    | "Para" -> Para (List.map to_inline (Util.to_list (element_contents e)))
+    | "Plain" -> Plain (List.map to_inline (Util.to_list (element_contents e)))
+    | "RawBlock" ->
+       let fmt, contents = to_pair (element_contents e) in
+       RawBlock (Util.to_string fmt, Util.to_string contents)
+    | "Div" ->
+       let a, l = to_pair (element_contents e) in
+       let a = to_attr a in
+       let l = Util.to_list l in
+       let l = List.map to_block l in
+       Div (a, l)
+    | _ -> UnhandledBlock e
+
+  let element t c = `Assoc ["t", `String t; "c", c]
+
+  let element_nc t = `Assoc ["t", `String t]
+
+  let of_attr (id, classes, keyvals) =
+    let id = `String id in
+    let classes = `List (List.map (fun s -> `String s) classes) in
+    let keyvals = `List (List.map (fun (k,v) -> `List [`String k; `String v]) keyvals) in
+    `List [id; classes; keyvals]
+
+  let of_list_attr (n, style, delim) =
+    let n = `Int n in
+    let style = match style with
+      | DefaultStyle -> "DefaultStyle"
+      | Example -> "Example"
+      | Decimal -> "Decimal"
+      | LowerRoman -> "LowerRoman"
+      | UpperRoman -> "UpperRoman"
+      | LowerAlpha -> "LowerAlpha"
+      | UpperAlpha -> "UpperAlpha"
+    in
+    let delim = match delim with
+      | DefaultDelim -> "DefaultDelim"
+      | Period -> "Period"
+      | OneParen -> "OneParen"
+      | TwoParensPeriod -> "TwoParensPeriod"
+    in
+    let style = `Assoc ["t", `String style] in
+    let delim = `Assoc ["t", `String delim] in
+    `List [n; style; delim]
+
+  let of_target (url, title) =
+    `List [`String url; `String title]
+
+  let rec of_block = function
+    | BulletList l -> element "BulletList" (`List (List.map of_blocks l))
+    | CodeBlock (a, s) -> element "CodeBlock" (`List [of_attr a; `String s])
+    | Header (n, a, t) -> element "Header" (`List [`Int n; of_attr a; of_inlines t])
+    | OrderedList (la, l) -> element "OrderedList" (`List [of_list_attr la; `List (List.map of_blocks l)])
+    | Para l -> element "Para" (of_inlines l)
+    | Plain l -> element "Plain" (of_inlines l)
+    | RawBlock (f, c) -> element "RawBlock" (`List [`String f; `String c])
+    | Div (a, l) -> element "Div" (`List [of_attr a; of_blocks l])
+    | UnhandledBlock b -> b
+  and of_blocks l =
+    `List (List.map of_block l)
+  and of_inline = function
+    | Code (a, t) ->
+       let a = of_attr a in
+       let t = `String t in
+       element "Code" (`List [a; t])
+    | Emph i ->
+      let i = List.map of_inline i in
+      element "Emph" (`List i)
+    | Image (a, i, t) ->
+       let a = of_attr a in
+       let i = of_inlines i in
+       let t = of_target t in
+       element "Image" (`List [a; i; t])
+    | Link (a, i, t) ->
+       let a = of_attr a in
+       let i = of_inlines i in
+       let t = of_target t in
+       element "Link" (`List [a; i; t])
+    | Quoted (q, i) ->
+       let q =
+         match q with
+         | DoubleQuote -> element_nc "DoubleQuote"
+         | SingleQuote -> element_nc "SingleQuote"
+       in
+       let i = List.map of_inline i in
+       let i = `List i in
+       element "Quoted" (`List [q; i])
+    | RawInline (f, s) ->
+      element "RawInline" (`List [`String f; `String s])
+    | SmallCaps i -> element "SmallCaps" (of_inlines i)
+    | Space -> element_nc "Space"
+    | Str s -> element "Str" (`String s)
+    | UnhandledInline i -> i
+  and of_inlines l =
+    `List (List.map of_inline l)
+end
+
+(** {2 Reading and writing} *)
+
+let of_json json =
+  let json = Util.to_assoc json in
+  let blocks = Util.to_list (List.assoc "blocks" json) in
+  let blocks = List.map JSON.to_block blocks in
+  let api_version = List.assoc "pandoc-api-version" json in
+  let api_version = List.map Util.to_int (Util.to_list api_version) in
+  let meta = List.assoc "meta" json in
+  { blocks; api_version; meta }
+
+let to_json p =
+  let blocks = `List (List.map JSON.of_block p.blocks) in
+  let api_version = `List (List.map (fun n -> `Int n) p.api_version) in
+  let meta = p.meta in
+  `Assoc ["blocks", blocks; "pandoc-api-version", api_version; "meta", meta]
+
+(** JSON from markdown file. *)
+let json_of_md_file fname =
+  let tmp = Filename.temp_file "pandoc" ".json" in
+  let cmd = Printf.sprintf "pandoc -f markdown -t json %s -o %s" fname tmp in
+  let n = Sys.command cmd in
+  assert (n = 0);
+  let json = from_file tmp in
+  Sys.remove tmp;
+  json
+
+let of_md_file fname =
+  let json = json_of_md_file fname in
+  of_json json
+
+let api_version p = p.api_version
+
+let blocks p = p.blocks
+
+(** {2 Metadata} *)
+
+type meta_value =
+  | MetaBool of bool
+  | MetaInlines of inline list
+  | MetaString of string
+  | MetaUnhandled of Yojson.Basic.t
+
+let of_meta e =
+  match JSON.element_type e with
+  | "MetaBool" -> MetaBool (Util.to_bool (JSON.element_contents e))
+  | "MetaInlines" -> MetaInlines (JSON.element_contents e |> Util.to_list |> List.map JSON.to_inline)
+  | "MetaString" -> MetaString (Util.to_string (JSON.element_contents e))
+  | _ -> MetaUnhandled e
+
+let meta p =
+  let m = Util.to_assoc p.meta in
+  List.map (fun (k,v) -> k, of_meta v) m
+
+let meta_bool p k =
+  match List.assoc k (meta p) with
+  | MetaBool b -> b
+  | MetaString "yes"
+  | MetaInlines [Str "yes"] -> true
+  | MetaString "no"
+  | MetaInlines [Str "no"] -> false
+  | _ -> raise Not_found
+
+let meta_string p k =
+  match List.assoc k (meta p) with
+  | MetaInlines l ->
+    List.map (function Str s -> s | Space -> " " | _ -> raise Not_found) l |> String.concat ""
+  | MetaString s -> s
+  | _ -> raise Not_found
+
+(** {2 Transforming} *)
+
+(** Change the list of blocks. *)
+let replace_blocks f p =
+  { p with blocks = f p.blocks }
+
+let map ?(block=(fun _ -> None)) ?(inline=(fun _ -> None)) p =
+  let rec map_block b =
+    match block b with
+    | Some bb -> bb
+    | None ->
+      match b with
+      | BulletList l -> [BulletList (List.map map_blocks l)]
+      | CodeBlock _ -> [b]
+      | Header (n, a, t) -> [Header (n, a, map_inlines t)]
+      | OrderedList (la, l) -> [OrderedList (la, List.map map_blocks l)]
+      | Para ii -> [Para (map_inlines ii)]
+      | Plain ii -> [Plain (map_inlines ii)]
+      | RawBlock _ -> [b]
+      | Div (la, l) -> [Div (la, map_blocks l)]
+      | UnhandledBlock _ -> [b]
+  and map_inline i =
+    match inline i with
+    | Some ii -> ii
+    | None ->
+      match i with
+      | Code _ -> [i]
+      | Emph i -> [Emph (map_inlines i)]
+      | Image (a, i, t) -> [Image (a, map_inlines i, t)]
+      | Link (a, i, t) -> [Link (a, map_inlines i, t)]
+      | Quoted (q, i) -> [Quoted (q, map_inlines i)]
+      | RawInline _ -> [i]
+      | SmallCaps i -> [SmallCaps (map_inlines i)]
+      | Space -> [i]
+      | Str _ -> [i]
+      | UnhandledInline _ -> [i]
+  and map_blocks bb = List.flatten (List.map map_block bb)
+  and map_inlines ii = List.flatten (List.map map_inline ii) in
+  replace_blocks map_blocks p
+
+let map_inlines f p =
+  let block = function
+    | Para ii -> Para (f ii)
+    | b -> b
+  in
+  replace_blocks (List.map block) p
+
+let map_blocks f p = map ~block:f p
+
+(** Map a function to every top-level block. *)
+let map_top_blocks f p =
+  replace_blocks (fun blocks -> List.flatten (List.map f blocks)) p

--- a/bin/pandoc-rwo/pandoc.mli
+++ b/bin/pandoc-rwo/pandoc.mli
@@ -1,0 +1,92 @@
+(** Library to write pandoc filters. *)
+
+(** {2 Types for pandoc} *)
+
+(** Attributes: identifier, classes, key/values. *)
+type attr = string * string list * (string * string) list
+
+(** Target of a link: url and title. *)
+type target = string * string
+
+type list_number_style = DefaultStyle | Example | Decimal | LowerRoman | UpperRoman | LowerAlpha | UpperAlpha
+
+type list_number_delim = DefaultDelim | Period | OneParen | TwoParensPeriod
+
+type list_attributes = int * list_number_style * list_number_delim
+
+type math_type = DisplayMath | InlineMath
+
+type quote_type = DoubleQuote | SingleQuote
+
+(** Format for raw blocks. *)
+type format = string
+
+(** Inline elements. *)
+type inline =
+  | Code of attr * string
+  | Emph of inline list
+  | Image of attr * inline list * target
+  | Link of attr * inline list * target
+  | Quoted of quote_type * inline list
+  | RawInline of string * string
+  | Space
+  | SmallCaps of inline list
+  | Str of string
+  | UnhandledInline of Yojson.Basic.t
+
+(** Block elements. *)
+and block =
+  | BulletList of block list list
+  | CodeBlock of attr * string
+  | Header of int * attr * inline list
+  | OrderedList of list_attributes * block list list
+  | Para of inline list
+  | Plain of inline list
+  | RawBlock of format * string
+  | Div of attr * block list
+  | UnhandledBlock of Yojson.Basic.t
+
+(** JSON representation of a pandoc file. *)
+type t
+
+(** {2 Reading and writing} *)
+
+(** Internal representation from JSON representation. *)
+val of_json : Yojson.Basic.t -> t
+
+(** JSON representation from internal representation. *)
+val to_json : t -> Yojson.Basic.t
+
+(** Construct representation of a markdown file. *)
+val of_md_file : string -> t
+
+(** API version. *)
+val api_version : t -> int list
+
+(** Blocks. *)
+val blocks : t -> block list
+
+(** {2 Metadata} *)
+
+(** Value of a boolean metadata. *)
+val meta_bool : t -> string -> bool
+
+(** Value of a string metadata. *)
+val meta_string : t -> string -> string
+
+(** {2 Mapping functions} *)
+
+(** General mapping function which maps a function on blocks and a function on
+    inlines. If the functions return [None] the mapping is further recursed
+    into. *)
+val map : ?block:(block -> block list option) -> ?inline:(inline -> inline list option) -> t -> t
+
+(** Map a function to every list of inlines. *)
+val map_inlines : (inline list -> inline list) -> t -> t
+
+(** Map a function to every block. If the function returns [None] then the block
+    is further recursed into. *)
+val map_blocks : (block -> block list option) -> t -> t
+
+(** Map a function to every block at toplevel. *)
+val map_top_blocks : (block -> block list) -> t -> t

--- a/bin/pandoc-rwo/pandoc_rwo.ml
+++ b/bin/pandoc-rwo/pandoc_rwo.ml
@@ -1,0 +1,19 @@
+(* Rewrite Pandoc notes to LaTeX highlight boxes *)
+let () =
+  let j = Yojson.Basic.from_channel stdin in
+  let p = Pandoc.of_json j in
+  let tex_block f  = Printf.ksprintf (fun b -> Pandoc.RawBlock ("tex", b)) f in
+  let f = function
+    | Pandoc.Div ((i,c,attr),b) as d -> begin
+       List.assoc_opt "data-type" attr |> function
+       | Some note ->
+          let bl =
+              tex_block "\\begin{%sBox}" note :: b @
+            [ tex_block "\\end{%sBox}" note ] in
+          Some [Pandoc.Div ((i,c,attr), bl)]
+       | None -> Some [d]
+    end 
+    | _ -> None in
+  let p = Pandoc.map ~block:f p in
+  let s = Yojson.Basic.pretty_to_string (Pandoc.to_json p) in
+  print_endline s

--- a/book/book.yml
+++ b/book/book.yml
@@ -17,11 +17,5 @@ lot: true
 author:
 - Yaron Minsky
 - Anil Madhavapeddy
-pandoc-latex-environment:
-  noteblock: [note]
-  tipblock: [tip]
-  warningblock: [warning]
-  cautionblock: [caution]
-  importantblock: [important]
 ---
 

--- a/book/cup-template.tex
+++ b/book/cup-template.tex
@@ -90,9 +90,9 @@ $if(listings)$
   keywordstyle=\color{bluekeywords},
   stringstyle=\color{redstrings},
   numberstyle=\color{graynumbers},
-  basicstyle=\ttfamily\footnotesize,
+  basicstyle=\ttfamily\small,
   frame=l,
-  rulecolor=\color{orangerule},
+  rulecolor=\color{white},
   framesep=10pt,
   xleftmargin=10pt,
   tabsize=4,
@@ -114,11 +114,10 @@ $if(listings)$
   {│}{\textSFxi}1%
   {┼}{\textSFv}1%
 }
-\definecolor{bluekeywords}{rgb}{0.0, 0.0, 0.4 }
-\definecolor{greencomments}{rgb}{0, 0.4, 0}
-\definecolor{redstrings}{rgb}{0.4, 0.0, 0.0}
+\definecolor{bluekeywords}{rgb}{0.0, 0.0, 0.5 }
+\definecolor{greencomments}{rgb}{0, 0.5, 0}
+\definecolor{redstrings}{rgb}{0.5, 0.0, 0.0}
 \definecolor{graynumbers}{rgb}{0.50, 0.50, 0.50}
-\definecolor{orangerule}{rgb}{1,0.84,.69}
 
 \hypersetup{
   colorlinks   = true, %Colours links instead of ugly boxes

--- a/book/cup-template.tex
+++ b/book/cup-template.tex
@@ -51,6 +51,27 @@
 \usepackage{csquotes}
 
 
+\usepackage[most]{tcolorbox}
+
+%textmarker style from colorbox doc
+\tcbset{textmarker/.style={%
+        enhanced,
+        parbox=false,boxrule=0mm,boxsep=0mm,arc=0mm,
+        outer arc=0mm,left=6mm,right=3mm,top=7pt,bottom=7pt,
+        toptitle=1mm,bottomtitle=1mm,oversize}}
+
+
+% define new colorboxes
+\newtcolorbox{hintBox}{textmarker,
+    borderline west={6pt}{0pt}{yellow},
+    colback=yellow!10!white}
+\newtcolorbox{warningBox}{textmarker,
+    borderline west={6pt}{0pt}{red},
+    colback=red!10!white}
+\newtcolorbox{noteBox}{textmarker,
+    borderline west={6pt}{0pt}{green},
+    colback=green!10!white}
+
 $if(listings)$
 \usepackage{listings,lstautogobble}
 \newcommand{\passthrough}[1]{#1}

--- a/book/cup-template.tex
+++ b/book/cup-template.tex
@@ -216,9 +216,9 @@ Alpha and Beta
 \end{dedication}
 \tocmax{2.10}{2.8.8}{}
 \tableofcontents
-\listoffigures
-\listoftables
-\listoffloatingboxes
+%\listoffigures
+%\listoftables
+%\listoffloatingboxes
 %  \listofcontributors
 %\chapter*{List of Contributors}
 %\begin{contriblist}

--- a/book/garbage-collector/README.md
+++ b/book/garbage-collector/README.md
@@ -323,16 +323,11 @@ incrementally by marking the heap in *slices*. Each value in the heap has a
 whether the value has been marked so that the GC can resume easily between
 slices. [major heaps/marking and scanning]{.idx}
 
-Tag color | Block status
-----------|-------------
-Blue | On the free list and not currently in use
-White (during marking) | Not reached yet, but possibly reachable
-White (during sweeping) | Unreachable and can be freed
-Gray | Reachable, but its fields have not been scanned
-Black | Reachable, and its fields have been scanned
-
-Table:  Tag color statuses
-
+- Blue:  On the free list and not currently in use
+- White (during marking): Not reached yet, but possibly reachable
+- White (during sweeping): Unreachable and can be freed
+- Gray: Reachable, but its fields have not been scanned
+- Black:  Reachable, and its fields have been scanned
 
 The color tags in the value headers store most of the state of the marking
 process, allowing it to be paused and resumed later. The GC and application

--- a/book/lists-and-patterns/README.md
+++ b/book/lists-and-patterns/README.md
@@ -852,7 +852,6 @@ check on whether the first two elements are equal:
 val destutter : int list -> int list = <fun>
 ```
 
-::: {data-type=note}
 ##### Polymorphic Compare
 
 You might have noticed that `destutter` is specialized to lists of integers.
@@ -949,8 +948,6 @@ opening the module again.
 ```ocaml env=main
 # open Base
 ```
-
-:::
 
 Note that `when` clauses have some downsides. As we noted earlier, the static
 checks associated with pattern matches rely on the fact that patterns are

--- a/book/variables-and-functions/README.md
+++ b/book/variables-and-functions/README.md
@@ -567,34 +567,26 @@ val ( *** ) : float -> float -> float = <fun>
 
 The syntactic role of an operator is typically determined by its first
 character or two, though there are a few exceptions.
-[Table2_1](variables-and-functions.html#table2_1){data-type=xref} breaks
-the different operators and other syntactic forms into groups from highest to
+The list below breaks the different operators and other syntactic forms into groups from highest to
 lowest precedence, explaining how each behaves syntactically. We write
 `!`... to indicate the class of operators beginning with `!`.
 
-::: {#table2_1 data-type=table}
-Operator prefix | Associativity
-----------------|--------------
-`!`..., `?`..., `~`... | Prefix
-`.`, `.(`, `.[` | -
-function application, constructor, `assert`, `lazy` | Left associative
-`-`, `-.` | Prefix
-`**`..., `lsl`, `lsr`, `asr` | Right associative
-`*`..., `/`..., `%`..., `mod`, `land`, `lor`, `lxor` | Left associative
-`+`..., `-`... | Left associative
-`::` | Right associative
-`@`..., `^`... | Right associative
-`=`..., `<`..., `>`..., `|`..., `&`..., `$`... | Left associative
-`&`, `&&` | Right associative
-`or`, `||` | Right associative
-`,` | -
-`<-`, `:=` | Right associative
-`if` | -
-`;` | Right associative
-
-Table:  Precedence and associativity
-:::
-
+-  `!`..., `?`..., `~`... (Prefix)
+- `.`, `.(`, `.[` | -
+- function application, constructor, `assert`, `lazy` | Left associative
+- `-`, `-.` | Prefix
+- `**`..., `lsl`, `lsr`, `asr` | Right associative
+- `*`..., `/`..., `%`..., `mod`, `land`, `lor`, `lxor` | Left associative
+- `+`..., `-`... | Left associative
+- `::` | Right associative
+- `@`..., `^`... | Right associative
+- `=`..., `<`..., `>`..., `|`..., `&`..., `$`... | Left associative
+- `&`, `&&` | Right associative
+- `or`, `||` | Right associative
+- `,` | -
+- `<-`, `:=` | Right associative
+- `if` | -
+- `;` | Right associative
 
 
 There's one important special case: `-` and `-.`, which are the integer and

--- a/book/variants/README.md
+++ b/book/variants/README.md
@@ -157,7 +157,6 @@ A muted gray...
 - : unit = ()
 ```
 
-::: {.allow_break data-type=note}
 ##### Variants, tuples and parens
 
 Variants with multiple arguments look an awful lot like tuples.
@@ -237,8 +236,6 @@ tuple. You can learn more about OCaml's memory representation in
 [Memory Representation of
 Values](runtime-memory-layout.html){data-type=xref}.
 
-
-:::
 
 ## Catch-All Cases and Refactoring
 

--- a/static-wip/dune
+++ b/static-wip/dune
@@ -10,10 +10,10 @@
 (rule
  (alias pdf-wip)
  (targets book.tex)
- (deps book.md EngD.cls ../book/book.yml ../book/cup-template.tex)
+ (deps ../bin/pandoc-rwo/pandoc_rwo.exe book.md EngD.cls ../book/book.yml ../book/cup-template.tex)
  (action
   (progn
-   (system "pandoc --top-level-division=part --metadata-file=../book/book.yml --template ../book/cup-template.tex --listings -o book.tex -t latex -s book.md"))))
+   (system "pandoc --top-level-division=part --filter=../bin/pandoc-rwo/pandoc_rwo.exe --metadata-file=../book/book.yml --template ../book/cup-template.tex --listings -o book.tex -t latex -s book.md"))))
 
 (rule
  (alias pdf-wip)

--- a/static/dune
+++ b/static/dune
@@ -10,10 +10,10 @@
 (rule
  (alias pdf)
  (targets book.tex)
- (deps book.md EngD.cls ../book/book.yml ../book/cup-template.tex)
+ (deps ../bin/pandoc-rwo/pandoc_rwo.exe book.md EngD.cls ../book/book.yml ../book/cup-template.tex)
  (action
   (progn
-   (system "pandoc --top-level-division=part --metadata-file=../book/book.yml --template ../book/cup-template.tex --listings -o book.tex -t latex -s book.md"))))
+   (system "pandoc --top-level-division=part --filter=../bin/pandoc-rwo/pandoc_rwo.exe --metadata-file=../book/book.yml --template ../book/cup-template.tex --listings -o book.tex -t latex -s book.md"))))
 
 (rule
  (alias pdf)


### PR DESCRIPTION
this uses a pandoc filter to rewrite markdown notes to tex. Vendors pandoc fork to support <div> with upstream PR  at https://github.com/smimram/ocaml-pandoc/pull/2
