### PR TITLE
remove references to core_kernel

### DIFF
--- a/book/compiler-frontend/examples/front-end/comparelib_test.ml
+++ b/book/compiler-frontend/examples/front-end/comparelib_test.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Core
 
 type t = {
   foo: string;

--- a/book/compiler-frontend/examples/front-end/comparelib_test.mli
+++ b/book/compiler-frontend/examples/front-end/comparelib_test.mli
@@ -1,4 +1,4 @@
-open Core_kernel
+open Core
 
 type t = {
   foo: string;

--- a/book/data-serialization/README.md
+++ b/book/data-serialization/README.md
@@ -60,7 +60,7 @@ converting s-expressions to and from strings. Let's rewrite our example
 s-expression in terms of this type:
 
 ```ocaml env=print_sexp
-# open Core_kernel
+# open Core
 # Sexp.List [
     Sexp.Atom "this";
     Sexp.List [ Sexp.Atom "is"; Sexp.Atom "an"];

--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -420,9 +420,9 @@ With this implementation, the build now succeeds!
 $ dune build freq.exe
 ```
 
-Now we can turn to optimizing the implementation of `Counter`. Here's an
-alternate and far more efficient implementation, based on the `Map` data
-structure in `Core_kernel`.
+Now we can turn to optimizing the implementation of `Counter`. Here's
+an alternate and far more efficient implementation, based on `Base`'s
+`Map` data structure.
 
 ```ocaml file=examples/correct/freq-fast/counter.ml
 open Base

--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -567,7 +567,7 @@ lightweight way:
 
 ```ocaml file=examples/erroneous/session_info/session_info.ml
 open Base
-module Time = Core_kernel.Time
+module Time = Core.Time
 
 module type ID = sig
   type t

--- a/book/files-modules-and-programs/examples/erroneous/session_info/dune
+++ b/book/files-modules-and-programs/examples/erroneous/session_info/dune
@@ -1,3 +1,3 @@
 (executable
   (name      session_info)
-  (libraries core_kernel))
+  (libraries core))

--- a/book/files-modules-and-programs/examples/erroneous/session_info/session_info.ml
+++ b/book/files-modules-and-programs/examples/erroneous/session_info/session_info.ml
@@ -1,5 +1,5 @@
 open Base
-module Time = Core_kernel.Time
+module Time = Core.Time
 
 module type ID = sig
   type t

--- a/book/first-class-modules/README.md
+++ b/book/first-class-modules/README.md
@@ -380,7 +380,7 @@ val u_of_sexp : Sexp.t -> u = <fun>
 val sexp_of_u : u -> Sexp.t = <fun>
 # sexp_of_u {a=3;b=7.}
 - : Sexp.t = ((a 3) (b 7))
-# u_of_sexp (Core_kernel.Sexp.of_string "((a 43) (b 3.4))")
+# u_of_sexp (Core.Sexp.of_string "((a 43) (b 3.4))")
 - : u = {a = 43; b = 3.4}
 ```
 

--- a/book/first-class-modules/README.md
+++ b/book/first-class-modules/README.md
@@ -625,7 +625,7 @@ interface:
       | None -> `Stop
       | Some line ->
         match Or_error.try_with (fun () ->
-          Core_kernel.Sexp.of_string line)
+          Core.Sexp.of_string line)
         with
         | Error e -> `Continue (Error.to_string_hum e)
         | Ok (Sexp.Atom "quit") -> `Stop

--- a/book/first-class-modules/examples/correct/query_handler_loader/dune
+++ b/book/first-class-modules/examples/correct/query_handler_loader/dune
@@ -1,4 +1,4 @@
 (executables
   (names      query_handler_loader query_handler)
-  (libraries  core core_kernel ppx_sexp_conv)
+  (libraries  core ppx_sexp_conv)
   (preprocess (pps ppx_sexp_conv)))

--- a/book/first-class-modules/examples/correct/query_handler_loader/query_handler_core.ml
+++ b/book/first-class-modules/examples/correct/query_handler_loader/query_handler_core.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Core
 
 module type Query_handler = sig
 

--- a/book/first-class-modules/examples/correct/query_handler_loader/query_handler_loader.ml
+++ b/book/first-class-modules/examples/correct/query_handler_loader/query_handler_loader.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Core
 open Query_handler_core
 
 [@@@part "1"];;

--- a/book/functors/README.md
+++ b/book/functors/README.md
@@ -718,7 +718,7 @@ val some_type_of_sexp : Sexp.t -> some_type = <fun>
 val sexp_of_some_type : some_type -> Sexp.t = <fun>
 # sexp_of_some_type (33, ["one"; "two"])
 - : Sexp.t = (33 (one two))
-# Core_kernel.Sexp.of_string "(44 (five six))" |> some_type_of_sexp
+# Core.Sexp.of_string "(44 (five six))" |> some_type_of_sexp
 - : some_type = (44, ["five"; "six"])
 ```
 
@@ -796,7 +796,7 @@ other:
 ```ocaml env=main
 # module type Interval_intf_with_sexp = sig
     include Interval_intf
-    include Core_kernel.Sexpable with type t := t
+    include Core.Sexpable with type t := t
   end
 module type Interval_intf_with_sexp =
   sig
@@ -821,7 +821,7 @@ signatures are being handled equivalently:
 # module type Interval_intf_with_sexp = sig
     type t
     include Interval_intf with type t := t
-    include Core_kernel.Sexpable      with type t := t
+    include Core.Sexpable      with type t := t
   end
 module type Interval_intf_with_sexp =
   sig
@@ -844,7 +844,7 @@ maintained when reading in from an s-expression:
 # module Make_interval(Endpoint : sig
       type t
       include Comparable with type t := t
-      include Core_kernel.Sexpable with type t := t
+      include Core.Sexpable with type t := t
     end)
     : (Interval_intf_with_sexp with type endpoint := Endpoint.t)
   = struct

--- a/book/garbage-collector/README.md
+++ b/book/garbage-collector/README.md
@@ -529,7 +529,7 @@ garbage collection behavior:
 
 ```sh dir=examples/barrier_bench
 $ dune build barrier_bench.exe
-$ dune exec -- ./barrier_bench.exe -help
+$ dune exec -- ./barrier_bench.exe -help | head -13
 Benchmark for mutable, immutable
 
   barrier_bench.exe [COLUMN ...]
@@ -543,95 +543,6 @@ Columns that can be specified are:
 	speedup    - Relative execution cost as a speedup.
 	samples    - Number of samples collected for profiling.
 
-Columns with no significant values will not be displayed. The
-following columns will be displayed by default:
-	time alloc percentage
-
-Error Estimates
-===============
-To display error estimates, prefix the column name (or
-regression) with a '+'. Example +time.
-
-(1) R^2 is the fraction of the variance of the responder (such as
-runtime) that is accounted for by the predictors (such as number of
-runs).  More informally, it describes how good a fit we're getting,
-with R^2 = 1 indicating a perfect fit and R^2 = 0 indicating a
-horrible fit. Also see:
-http://en.wikipedia.org/wiki/Coefficient_of_determination
-
-(2) Bootstrapping is used to compute 95% confidence intervals
-for each estimate.
-
-Because we expect runtime to be very highly correlated with number of
-runs, values very close to 1 are typical; an R^2 value for 'time' that
-is less than 0.99 should cause some suspicion, and a value less than
-0.9 probably indicates either a shortage of data or that the data is
-erroneous or peculiar in some way.
-
-Specifying additional regressions
-=================================
-The builtin in columns encode common analysis that apply to most
-functions. Bench allows the user to specify custom analysis to help
-understand relationships specific to a particular function using the
-flag "-regression" . It is worth noting that this feature requires
-some understanding of both linear regression and how various quatities
-relate to each other in the OCaml runtime.  To specify a regression
-one must specify the responder variable and a command separated list
-of predictor variables.
-
-For example: +Time:Run,mjGC,Comp
-
-which asks bench to estimate execution time using three predictors
-namely the number of runs, major GCs and compaction stats and display
-error estimates. Drop the prefix '+' to suppress error estimation. The
-variables available for regression include:
-	Time  - Time
-	Cycls - Cycles
-	Run   - Runs per sampled batch
-	mGC   - Minor Collections
-	mjGC  - Major Collections
-	Comp  - Compactions
-	mWd   - Minor Words
-	mjWd  - Major Words
-	Prom  - Promoted Words
-	One   - Constant predictor for estimating measurement overhead
-
-=== flags ===
-
-  [-all-values]           Show all column values, including very small ones.
-  [-ascii]                Display data in simple ascii based tables.
-  [-ci-absolute]          Display 95% confidence interval in absolute numbers
-  [-clear-columns]        Don't display default columns. Only show user
-                          specified ones.
-  [-display STYLE]        Table style (short, tall, line, blank or column).
-                          Default short.
-  [-fork]                 Fork and run each benchmark in separate child-process
-  [-geometric SCALE]      Use geometric sampling. (default 1.01)
-  [-linear INCREMENT]     Use linear sampling to explore number of runs, example
-                          1.
-  [-load FILE] ...        Analyze previously saved data files and don't run
-                          tests. [-load] can be specified multiple times.
-  [-no-compactions]       Disable GC compactions.
-  [-overheads]            Show measurement overheads, when applicable.
-  [-quota <INT>x|<SPAN>]  Quota allowed per test. May be a number of runs (e.g.
-                          1000x or 1e6x) or a time span (e.g. 10s or 500ms).
-                          Default 10s.
-  [-reduced-bootstrap]    Reduce the number of bootstrapping iterations
-  [-regression REGR] ...  Specify additional regressions (See -? help).
-  [-save]                 Save benchmark data to <test name>.txt files.
-  [-sexp]                 Output as sexp.
-  [-stabilize-gc]         Stabilize GC between each sample capture.
-  [-thin-overhead INT]    If given, just run the test function(s) N times; skip
-                          measurements and regressions. Float lexemes like "1e6"
-                          are allowed.
-  [-v]                    High verbosity level.
-  [-width WIDTH]          width limit on column display (default 200).
-  [-build-info]           print info about this build and exit
-  [-version]              print the version of this build and exit
-  [-help]                 print this help text and exit
-                          (alias: -?)
-
-...
 ```
 
 The `-no-compactions` and `-stabilize-gc` options can help force a situation

--- a/book/garbage-collector/README.md
+++ b/book/garbage-collector/README.md
@@ -147,13 +147,13 @@ the `Gc.set` function:
 :::
 
 ```ocaml env=tune
-# open Core_kernel
+# open Core
 # let c = Gc.get ()
 val c : Core_kernel.Gc.control =
-  {Core_kernel.Gc.Control.minor_heap_size = 262144;
-   major_heap_increment = 15; space_overhead = 80; verbose = 0;
-   max_overhead = 500; stack_limit = 1048576; allocation_policy = 0;
-   window_size = 1; custom_major_ratio = 44; custom_minor_ratio = 100;
+  {Core.Gc.Control.minor_heap_size = 262144; major_heap_increment = 15;
+   space_overhead = 80; verbose = 0; max_overhead = 500;
+   stack_limit = 1048576; allocation_policy = 0; window_size = 1;
+   custom_major_ratio = 44; custom_minor_ratio = 100;
    custom_minor_max_size = 8192}
 # Gc.tune ~minor_heap_size:(262144 * 2) ()
 - : unit = ()
@@ -542,6 +542,94 @@ Columns that can be specified are:
 	percentage - Relative execution time as a percentage.
 	speedup    - Relative execution cost as a speedup.
 	samples    - Number of samples collected for profiling.
+
+Columns with no significant values will not be displayed. The
+following columns will be displayed by default:
+	time alloc percentage
+
+Error Estimates
+===============
+To display error estimates, prefix the column name (or
+regression) with a '+'. Example +time.
+
+(1) R^2 is the fraction of the variance of the responder (such as
+runtime) that is accounted for by the predictors (such as number of
+runs).  More informally, it describes how good a fit we're getting,
+with R^2 = 1 indicating a perfect fit and R^2 = 0 indicating a
+horrible fit. Also see:
+http://en.wikipedia.org/wiki/Coefficient_of_determination
+
+(2) Bootstrapping is used to compute 95% confidence intervals
+for each estimate.
+
+Because we expect runtime to be very highly correlated with number of
+runs, values very close to 1 are typical; an R^2 value for 'time' that
+is less than 0.99 should cause some suspicion, and a value less than
+0.9 probably indicates either a shortage of data or that the data is
+erroneous or peculiar in some way.
+
+Specifying additional regressions
+=================================
+The builtin in columns encode common analysis that apply to most
+functions. Bench allows the user to specify custom analysis to help
+understand relationships specific to a particular function using the
+flag "-regression" . It is worth noting that this feature requires
+some understanding of both linear regression and how various quatities
+relate to each other in the OCaml runtime.  To specify a regression
+one must specify the responder variable and a command separated list
+of predictor variables.
+
+For example: +Time:Run,mjGC,Comp
+
+which asks bench to estimate execution time using three predictors
+namely the number of runs, major GCs and compaction stats and display
+error estimates. Drop the prefix '+' to suppress error estimation. The
+variables available for regression include:
+	Time  - Time
+	Cycls - Cycles
+	Run   - Runs per sampled batch
+	mGC   - Minor Collections
+	mjGC  - Major Collections
+	Comp  - Compactions
+	mWd   - Minor Words
+	mjWd  - Major Words
+	Prom  - Promoted Words
+	One   - Constant predictor for estimating measurement overhead
+
+=== flags ===
+
+  [-all-values]           Show all column values, including very small ones.
+  [-ascii]                Display data in simple ascii based tables.
+  [-ci-absolute]          Display 95% confidence interval in absolute numbers
+  [-clear-columns]        Don't display default columns. Only show user
+                          specified ones.
+  [-display STYLE]        Table style (short, tall, line, blank or column).
+                          Default short.
+  [-fork]                 Fork and run each benchmark in separate child-process
+  [-geometric SCALE]      Use geometric sampling. (default 1.01)
+  [-linear INCREMENT]     Use linear sampling to explore number of runs, example
+                          1.
+  [-load FILE] ...        Analyze previously saved data files and don't run
+                          tests. [-load] can be specified multiple times.
+  [-no-compactions]       Disable GC compactions.
+  [-overheads]            Show measurement overheads, when applicable.
+  [-quota <INT>x|<SPAN>]  Quota allowed per test. May be a number of runs (e.g.
+                          1000x or 1e6x) or a time span (e.g. 10s or 500ms).
+                          Default 10s.
+  [-reduced-bootstrap]    Reduce the number of bootstrapping iterations
+  [-regression REGR] ...  Specify additional regressions (See -? help).
+  [-save]                 Save benchmark data to <test name>.txt files.
+  [-sexp]                 Output as sexp.
+  [-stabilize-gc]         Stabilize GC between each sample capture.
+  [-thin-overhead INT]    If given, just run the test function(s) N times; skip
+                          measurements and regressions. Float lexemes like "1e6"
+                          are allowed.
+  [-v]                    High verbosity level.
+  [-width WIDTH]          width limit on column display (default 200).
+  [-build-info]           print info about this build and exit
+  [-version]              print the version of this build and exit
+  [-help]                 print this help text and exit
+                          (alias: -?)
 
 ...
 ```

--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -17,34 +17,32 @@ Before going any further, make sure you've followed the steps in [the
 installation page](install.html).
 
 ::: {data-type=note}
-##### `Base`, `Core` and `Core_kernel`
+##### `Base` and `Core`
 
-`Base` is one of a family of three standard library replacements, each with
-different use-cases, each building on the last. Here's a quick summary.
+`Base` comes along with another, yet more extensive standard library
+replacement, called `Core`.  We're going to mostly stick to `Base`,
+but it's worth understanding the differences between these libraries.
 
-- *`Base`* is designed to provide the fundamentals needed from a standard
-  library. It has a variety of basic efficient data structures like
-  hash-tables, sets and sequences. It also defines the basic idioms for error
-  handling and serialization, and contains well organized APIs for every
-  basic data type from integers to lazy values. This comes along with a
-  minimum of external dependencies, so `Base` just takes seconds to build and
-  install. It's also portable, running on every platform that OCaml does,
-  including Windows and JavaScript.
+- *`Base`* is designed to be lightweight, portable, and stable, while
+  providing all of the fundamentals you need from a standard library.
+  It comes with a minimum of external dependencies, so `Base` just
+  takes seconds to build and install.
 
-- *`Core_kernel`* extends `Base` with many new data structures, like
-  heaps, types to represent times and time-zones, support for
-  efficient binary serializers, and other capabilities. It's still
-  portable, but has many more dependencies, takes longer to build, and
-  will add more to the size of your executables.
+- *`Core`* extends `Base` in a number of ways: it adds new data
+  structures, like heaps, hash-sets, and functional queues; it
+  provides types to represent times and time-zones; well-integrated
+  support for efficient binary serializers; and much more.  At the
+  same time, it has many more dependencies, and so takes longer to
+  build, and will add more to the size of your executables.
 
-- *`Core`* is the most full-featured, extending `Core_kernel` with support
-  for a variety of UNIX APIs, but only works on UNIX-like OSs, including
-  Linux and macOS.
+As of this writing, the stable release of `Core` is less portable than
+`Base`, running only on UNIX-like systems.  For that reason, there's
+yet a third library, `Core_kernel`, which is a portable subset of
+`Core`. That said, the latest development version removes
+`Core_kernel`, and makes `Core` itself portable.  The stable release
+should have `Core_kernel` removed by early 2022, so we won't use
+`Core_kernel` in this text.
 
-We use `Base` in this section, but you should check out `Core` and
-`Core_kernel`, depending on your requirements. We'll discuss some of the
-additional functionality provided by `Core` and `Core_kernel` later in the
-book.
 :::
 
 
@@ -53,8 +51,7 @@ you can try out the examples as you read through the chapter.
 
 ## OCaml as a Calculator
 
-Our first step is to open `Base`: [OCaml/numerical calculations
-in]{.idx}[numerical calculations]{.idx}[Core standard library/opening]{.idx}
+Our first step is to open `Base`:
 
 ```ocaml env=main
 # open Base

--- a/book/imperative-programming/README.md
+++ b/book/imperative-programming/README.md
@@ -498,7 +498,7 @@ respectively.
 Another common imperative data structure is the doubly linked
 list. Doubly linked lists can be traversed in both directions, and
 elements can be added and removed from the list in constant
-time. Core_kernel defines a doubly linked list (the module is called
+time. Core defines a doubly linked list (the module is called
 `Doubly_linked`), but we'll define our own linked list library as an
 illustration. [lists/doubly-linked lists]{.idx}[doubly-linked
 lists]{.idx}[imperative programming/doubly-linked lists]{.idx
@@ -674,7 +674,7 @@ This shouldn't be a big surprise. Complex imperative data structures
 can be quite tricky, considerably trickier than their pure
 equivalents. The issues described previously can be dealt with by more
 careful error detection, and such error correction is taken care of in
-modules like Core_kernel's `Doubly_linked`. You should use imperative
+modules like Core's `Doubly_linked`. You should use imperative
 data structures from a well-designed library when you can. And when
 you can't, you should make sure to put great care into your error
 handling. [imperative programming/drawbacks of]{.idx}[Doubly-linked
@@ -716,7 +716,7 @@ let find_el t ~f =
 This completes our implementation, but there's still considerably more
 work to be done to make a really usable doubly linked list. As
 mentioned earlier, you're probably better off using something like
-Core_kernel's `Doubly_linked` module that has a more complete
+Core `Doubly_linked` module that has a more complete
 interface and has more of the tricky corner cases worked
 out. Nonetheless, this example should serve to demonstrate some of the
 techniques you can use to build nontrivial imperative data structure

--- a/book/json/README.md
+++ b/book/json/README.md
@@ -83,7 +83,7 @@ Once installed, you can open it in the `utop` toplevel by:
 :::
 
 ```ocaml env=install
-# open Core_kernel
+# open Core
 # #require "yojson"
 # open Yojson
 ```

--- a/book/json/prelude.ml
+++ b/book/json/prelude.ml
@@ -1,6 +1,6 @@
 #require "core,core.top,yojson";;
 
-open Core_kernel;;
+open Core;;
 
 let () = Printexc.record_backtrace false
 

--- a/book/lists-and-patterns/README.md
+++ b/book/lists-and-patterns/README.md
@@ -1024,7 +1024,7 @@ should prefer patterns wherever they are sufficient.
 
 As a side note, the above implementation of `count_some` is longer than
 necessary; even worse, it is not tail recursive. In real life, you would
-probably just use the `List.count` function from `Core_kernel`:
+probably just use the `List.count` function:
 
 ```ocaml env=main
 # let count_some l = List.count ~f:Option.is_some l

--- a/book/maps-and-hashtables/README.md
+++ b/book/maps-and-hashtables/README.md
@@ -453,12 +453,11 @@ Error: This expression has type
 
 ### The Polymorphic Comparator
 
-We don't need to generate specialized comparators for every type we want to
-build a map on. We can instead build a map based on OCaml's built-in
-polymorphic comparison function, which was discussed in
-[Lists And Patterns](lists-and-patterns.html#lists-and-patterns){data-type=xref}.
-`Base` currently doesn't have a convenient function for minting maps based on
-polymorphic compare, but `Core_kernel` does, as we can see below.
+We don't need to generate specialized comparators for every type we
+want to build a map on. We can instead build a map based on OCaml's
+built-in polymorphic comparison function, which was discussed in
+[Lists And Patterns
+](lists-and-patterns.html#lists-and-patterns){data-type=xref}.
 [maps/polymorphic comparison in]{.idx}[polymorphic comparisons]{.idx}
 
 ```ocaml env=main
@@ -466,9 +465,9 @@ polymorphic compare, but `Core_kernel` does, as we can see below.
 - : (int, string) Map.Poly.t = <abstr>
 ```
 
-Note that maps based on the polymorphic comparator have different comparator
-witnesses than those based on the type-specific comparison function. Thus,
-the compiler rejects the following:
+Note that maps based on the polymorphic comparator have different
+comparator witnesses than those based on the type-specific comparison
+function. Thus, the compiler rejects the following:
 
 ```ocaml env=main
 # Map.symmetric_diff

--- a/book/maps-and-hashtables/README.md
+++ b/book/maps-and-hashtables/README.md
@@ -660,10 +660,10 @@ field within the same structure), the `=` operator will never terminate, and
 your program will hang! You therefore must use the physical equality operator
 or write a custom comparison function when comparing cyclic values.
 
-It's quite easy to mix up the use of `=` and `==`, so Core_kernel discourages
-the use of `==` and provides the more explicit `phys_equal` function instead.
-You'll see a warning if you use `==` anywhere in code that opens
-`Core_kernel`:
+It's quite easy to mix up the use of `=` and `==`, so `Base`
+discourages the use of `==` and provides the more explicit
+`phys_equal` function instead.  You'll see a warning if you use `==`
+anywhere in code that opens `Base`:
 
 ```ocaml env=core_phys_equal
 # open Base

--- a/book/prologue/README.md
+++ b/book/prologue/README.md
@@ -242,12 +242,13 @@ on how to set it up and what packages to install can be found at
 [the installation page](install.html).[installation
 instructions]{.idx}[OCaml/installation instructions]{.idx}
 
-`Core` requires a UNIX based operating system, and so only works on systems
-like macOS, Linux, FreeBSD, and OpenBSD or the Windows Subsystem for Linux
-(WSL).  Core includes a portable subset called `Core_kernel` which works
-anywhere OCaml is, and in particular works on Windows and JavaScript. The
-examples in Part I of the book will only use `Core_kernel` and other highly
-portable libraries.[OCaml/operating system support]{.idx}
+`Core` currently requires a UNIX based operating system, and so only
+works on systems like macOS, Linux, FreeBSD, and OpenBSD or the
+Windows Subsystem for Linux (WSL).  `Core` is an extension of `Base`
+which works anywhere OCaml does, and in particular works on Windows
+and JavaScript. The examples in Part I of the book will for the most
+part use only `Base` and other highly portable
+libraries.[OCaml/operating system support]{.idx}
 
 This book is not intended as a reference manual.  We aim to teach you
 about the language as well as the libraries, tools, and techniques

--- a/book/testing/README.md
+++ b/book/testing/README.md
@@ -1020,7 +1020,7 @@ creating a generator for pairs from two generators for the constituent
 types.
 
 ```ocaml env=main
-# open Core_kernel
+# open Core
 # Quickcheck.Generator.both
 - : 'a Base_quickcheck.Generator.t ->
     'b Base_quickcheck.Generator.t -> ('a * 'b) Base_quickcheck.Generator.t

--- a/book/testing/README.md
+++ b/book/testing/README.md
@@ -920,13 +920,13 @@ seems like a problem.
 This is a place where `Quickcheck` can help.  `Quickcheck` is a
 library to help automate the construction of testing
 distributions. Let's try rewriting the above example using it.  Note
-that we open `Core_kernel` here because `Core_kernel` has nicely
-integrated support for `Quickcheck`, with helper functions already
-integrated into most common modules.  There's also a standalone
-`Base_quickcheck` library that can be used without `Core_kernel`.
+that we open `Core` here because `Core` has nicely integrated support
+for `Quickcheck`, with helper functions already integrated into most
+common modules.  There's also a standalone `Base_quickcheck` library
+that can be used without `Core`.
 
 ```ocaml file=examples/erroneous/quickcheck_property_test/test.ml
-open Core_kernel
+open Core
 
 let%test_unit "negation flips the sign" =
   Quickcheck.test ~sexp_of:[%sexp_of: int]
@@ -997,7 +997,7 @@ distribution for generating pairs of lists of integers.  The following
 example shows how that can be done using Quickcheck's combinators.
 
 ```ocaml file=examples/correct/bigger_quickcheck_test/test.ml
-open Core_kernel
+open Core
 
 let gen_int_list_pair =
   let int_list_gen =
@@ -1033,7 +1033,7 @@ creation of the generator given just the type declaration.  We can use
 that to simplify our code, as shown below.
 
 ```ocaml file=examples/correct/bigger_quickcheck_test_with_ppx/test.ml
-open Core_kernel
+open Core
 
 let%test_unit "List.rev_append is List.append of List.rev" =
   Quickcheck.test

--- a/book/testing/dune
+++ b/book/testing/dune
@@ -3,7 +3,7 @@
  (packages
   base
   base_quickcheck
-  core_kernel
+  core
   lambdasoup
   mdx
   patdiff

--- a/book/testing/dune.inc
+++ b/book/testing/dune.inc
@@ -4,7 +4,7 @@
   (:x README.md)
   (package base)
   (package base_quickcheck)
-  (package core_kernel)
+  (package core)
   (package lambdasoup)
   (package mdx)
   (package ppx_jane)

--- a/book/testing/examples/correct/bigger_quickcheck_test/dune
+++ b/book/testing/examples/correct/bigger_quickcheck_test/dune
@@ -1,6 +1,6 @@
 (library
  (name foo)
- (libraries base stdio core_kernel)
+ (libraries base stdio core)
  (preprocess
   (pps ppx_jane))
  (inline_tests))

--- a/book/testing/examples/correct/bigger_quickcheck_test/test.ml
+++ b/book/testing/examples/correct/bigger_quickcheck_test/test.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Core
 
 let gen_int_list_pair =
   let int_list_gen =

--- a/book/testing/examples/correct/bigger_quickcheck_test_with_ppx/dune
+++ b/book/testing/examples/correct/bigger_quickcheck_test_with_ppx/dune
@@ -1,5 +1,5 @@
 (library
  (name foo)
- (libraries base stdio core_kernel)
+ (libraries base stdio core)
  (preprocess (pps ppx_jane))
  (inline_tests))

--- a/book/testing/examples/correct/bigger_quickcheck_test_with_ppx/test.ml
+++ b/book/testing/examples/correct/bigger_quickcheck_test_with_ppx/test.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Core
 
 let%test_unit "List.rev_append is List.append of List.rev" =
   Quickcheck.test

--- a/book/testing/examples/erroneous/monadic_quickcheck_test/dune
+++ b/book/testing/examples/erroneous/monadic_quickcheck_test/dune
@@ -1,6 +1,6 @@
 (library
  (name foo)
- (libraries base stdio core_kernel)
+ (libraries base stdio core)
  (preprocess
   (pps ppx_jane))
  (inline_tests))

--- a/book/testing/examples/erroneous/monadic_quickcheck_test/test.ml
+++ b/book/testing/examples/erroneous/monadic_quickcheck_test/test.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Core
 
 let%test_unit "List.rev_append is List.append of List.rev" =
   let gen_list = List.gen_non_empty (Int.gen_incl Int.min_value Int.max_value) in

--- a/book/testing/examples/erroneous/quickcheck_property_test/dune
+++ b/book/testing/examples/erroneous/quickcheck_property_test/dune
@@ -1,6 +1,6 @@
 (library
  (name foo)
- (libraries base stdio core_kernel)
+ (libraries base stdio core)
  (preprocess
   (pps ppx_jane))
  (inline_tests))

--- a/book/testing/examples/erroneous/quickcheck_property_test/test.ml
+++ b/book/testing/examples/erroneous/quickcheck_property_test/test.ml
@@ -1,4 +1,4 @@
-open Core_kernel
+open Core
 
 let%test_unit "negation flips the sign" =
   Quickcheck.test ~sexp_of:[%sexp_of: int]

--- a/book/testing/prelude.ml
+++ b/book/testing/prelude.ml
@@ -1,5 +1,5 @@
 #require "base";;
-#require "core_kernel";;
+#require "core";;
 #require "ppx_jane";;
 #require "base_quickcheck";;
 #require "lambdasoup";;

--- a/book/variants/README.md
+++ b/book/variants/README.md
@@ -362,7 +362,7 @@ can achieve with this by reiterating the `Log_entry` message type that
 was described in [Records](records.html#records){data-type=xref}.
 
 ```ocaml env=main
-module Time_ns = Core_kernel.Time_ns
+module Time_ns = Core.Time_ns
 module Log_entry = struct
   type t =
     { session_id: string;
@@ -810,7 +810,7 @@ val not_ : 'a expr -> 'a expr = <fun>
 ```
 
 The example of a Boolean expression language is more than a
-toy. There's a module very much in this spirit in `Core_kernel` called
+toy. There's a module very much in this spirit in `Core` called
 `Blang` (short for "Boolean language"), and it gets a lot of practical
 use in a variety of applications.  The simplification algorithm in
 particular is useful when you want to use it to specialize the


### PR DESCRIPTION
Quite mechanical, with a few stale descriptions of Core_kernel removed, and an update to the language in the prologue and the guided tour.