### PR TITLE
Remove {.idx #fragment} syntax that causes render issue in PDF

### DIFF
--- a/book/variables-and-functions/README.md
+++ b/book/variables-and-functions/README.md
@@ -498,7 +498,7 @@ definition that extends and supersedes an existing one by shadowing it.
 So far, we've seen examples of functions used in both prefix and infix
 style.[operators/prefix and infix operators]{.idx}[infix
 operators]{.idx}[prefix operators]{.idx}[functions/prefix and infix
-operators]{.idx #FNCprf}
+operators]{.idx}
 
 ```ocaml env=main
 # Int.max 3 4  (* prefix *)
@@ -940,8 +940,8 @@ care to be consistent in your ordering of labeled arguments.
 An optional argument is like a labeled argument that the caller can choose
 whether or not to provide. Optional arguments are passed in using the same
 syntax as labeled arguments, and, like labeled arguments, can be provided in
-any order.[arguments/optional arguments]{.idx #ARGopt}[functions/optional
-arguments]{.idx #FNCopt}
+any order.[arguments/optional arguments]{.idx}[functions/optional
+arguments]{.idx}
 
 Here's an example of a string concatenation function with an optional
 separator. This function uses the `^` operator for pairwise string


### PR DESCRIPTION
The syntax `{.idx #fragment}`, which appears in 2 places in the source markdown, causes text to appear in the PDF that shouldn't be there. Here are screenshots of the two places where it happens:

> <img src="https://user-images.githubusercontent.com/184773/136138637-a32de3b4-e468-42cd-8eb4-d1cef7d5ff60.png" width="500">

> <img src="https://user-images.githubusercontent.com/184773/136139111-9795d9c0-0c79-4d1d-b115-f655c38fe3a4.png" width="500">

I'm not sure what this `{.idx #fragment}` syntax does, but the trend in recent commits has been to replace it with `{.idx}`. I did so in this PR and it fixes the PDF output. Hopefully this is the correct solution to the issue :)

> <img src="https://user-images.githubusercontent.com/184773/136138908-8b5606b9-3c96-4648-afcc-23f4a2cb4cc3.png" width="500">

> <img src="https://user-images.githubusercontent.com/184773/136138896-421ea9f8-ea91-495d-aa6e-92c0932be6f9.png" width="500">


