### PR TITLE
Fix link to ocp-indent

### DIFF
--- a/book/install.html
+++ b/book/install.html
@@ -189,7 +189,7 @@ opam install core async yojson core_extended \
     <li> <a href="https://github.com/ocaml/merlin">Merlin</a>, which
       provides out of your code, like auto-completion,
       go-to-definition, and type-throwback.</li>
-    <li> <a href="https://github.com/ocaml-ppx/ocamlformat">ocp-indent</a>,
+    <li> <a href="https://github.com/OCamlPro/ocp-indent">ocp-indent</a>,
       which auto-indents your code.
     <li> <a href="https://github.com/ocaml-ppx/ocamlformat">ocamlformat</a>,
       which provides fully automatic formatting and indentation


### PR DESCRIPTION
It was linking to https://github.com/ocaml-ppx/ocamlformat instead