### PR TITLE
Remove `require-package` labels

### DIFF
--- a/book/concurrent-programming/README.md
+++ b/book/concurrent-programming/README.md
@@ -989,7 +989,7 @@ let () =
 And that's all we need for a simple but usable definition
 searcher:
 
-```sh dir=examples/correct/search,require-package=textwrap,require-package=yojson,non-deterministic
+```sh dir=examples/correct/search,non-deterministic
 $ dune exec -- ./search.exe "Concurrent Programming" "OCaml"
 Concurrent Programming
 ----------------------

--- a/book/garbage-collector/README.md
+++ b/book/garbage-collector/README.md
@@ -542,7 +542,7 @@ garbage collection occurring:
   (libraries core core_bench))
 ```
 
-```sh dir=examples/barrier_bench,non-deterministic=command,require-package=core_bench
+```sh dir=examples/barrier_bench,non-deterministic=command
 $ dune exec -- ./barrier_bench.exe -ascii alloc -quota 1
 Estimated testing time 2s (2 benchmarks x 1s). Change using '-quota'.
 
@@ -682,7 +682,7 @@ Building and running this should show the following output:
 
 
 
-```sh dir=examples/finalizer,require-package=async
+```sh dir=examples/finalizer
 $ dune build finalizer.exe
 $ dune exec -- ./finalizer.exe
        immediate int: FAIL


### PR DESCRIPTION
These were only used for `mdx rule` but since the code uses the dune `mdx` stanza now this is declared in the `dune` file instead.