### PR TITLE
Build updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ocaml/opam:ubuntu
-RUN sudo apt-get update && sudo apt-get -y install python-pygments tzdata
+RUN sudo apt-get update && sudo apt-get -y install python3-pygments tzdata
 ENV OPAMYES=1
 WORKDIR /home/opam/src
 
@@ -23,8 +23,8 @@ WORKDIR /tmp
 RUN sudo apt-get update && sudo apt-get -y install texlive-full
 WORKDIR /home/opam/src
 
-# compile the project
-COPY . /home/opam/src/
-RUN sudo chown -R opam /home/opam/src
-RUN opam exec -- make
-RUN opam exec -- make test
+## compile the project
+#COPY . /home/opam/src/
+#RUN sudo chown -R opam /home/opam/src
+#RUN opam exec -- make generate
+#RUN opam exec -- make test

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ all:
 
 generate:
 	@dune build @site @pdf
+	cd /data/_build/default/static ; pandoc --top-level-division=part --filter=../bin/pandoc-rwo/pandoc_rwo.exe --metadata-file=../book/book.yml --listings -o book.epub -t epub -s book.md
 	@echo The site and the pdf have been generated in _build/default/static/
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
-.PHONY: all clean publish promote test test-all docker depext \
+.PHONY: all generate clean publish promote test test-all docker bash depext \
 	duniverse-init duniverse-upgrade
 
 DUNIVERSE ?= duniverse
+HERE := $(shell pwd)
 
 all:
+	docker run --rm -it -v "$(HERE):/data" ocaml/rwo bash -c 'make -C /data generate && make -C /data test'
+
+generate:
 	@dune build @site @pdf
 	@echo The site and the pdf have been generated in _build/default/static/
 
@@ -19,9 +23,13 @@ promote:
 clean:
 	dune clean
 
+depext: docker
+
 docker:
 	docker build -t ocaml/rwo .
 
+bash:
+	docker run --rm -it -v "$(HERE):/data" ocaml/rwo bash
 
 server:
 	cohttp-server-lwt _build/default/static-wip


### PR DESCRIPTION
The instructions in the `readme` for installing the dependencies to build the book seem incorrect. There is no `depext` target, but based on what _is_ there, I think it's safe to assume that the Docker target is the one that lines up the build dependencies. But the Dockerfile both accumulates dependencies _and_ builds the book, which isn't right, so I separated those into two discrete Makefile targets.

A lot of this backsolves the intent of how it should work from what's present in the project. It makes a few assumptions. Feel free to decline if this doesn't align with the actual intent of how the build should work.

The second commit adds an epub target, which was my original intent behind all this — to get a variant of the book to read on an eInk device. There's probably a better way to do this step, using Dune, but I don't yet know Dune or OCaml. Feel free to discard that second commit or refactor it to something more dune-like.