### PR TITLE
add empty line for code-paragraph separation

### DIFF
--- a/book/objects/README.md
+++ b/book/objects/README.md
@@ -384,6 +384,7 @@ area.  [width subtyping]{.idx}[subtyping/width subtyping]{.idx}
 # type shape = < area : float >
 type shape = < area : float >
 ```
+
 Now let's add a type representing a specific kind of shape, as well as
 a function for creating objects of that type.
 


### PR DESCRIPTION
There are escaped ` ``` ` in generated md (and pdf) due to no newline between code and paragraph

Before:
![image](https://user-images.githubusercontent.com/19646569/149326868-6dc2a107-dd49-4c3e-89c4-e541236be2de.png)
![image](https://user-images.githubusercontent.com/19646569/149327256-6dab8652-2eca-4b0b-a2b5-d42a7c96f29e.png)

After: 
![image](https://user-images.githubusercontent.com/19646569/149326778-17a8c100-109c-4e1d-a0f2-6f7d90f66941.png)
![image](https://user-images.githubusercontent.com/19646569/149327417-ecfb664a-54ff-4c0d-acc8-052aeb79d3d5.png)
