### PR TITLE
add coverage of bytes

### DIFF
--- a/book/imperative-programming/README.md
+++ b/book/imperative-programming/README.md
@@ -307,24 +307,31 @@ structures) will lead to an exception being thrown.
 Array literals are written using `[|` and `|]` as delimiters. Thus,
 `[| 1; 2; 3 |]` is a literal integer array.
 
-#### Strings
+#### `bytes` and `string`s.
 
-Strings are essentially byte arrays which are often used for textual data.
-The main advantage of using a `string` in place of a `Char.t array` (a
-`Char.t` is an 8-bit character) is that the former is considerably more
-space-efficient; an array uses one word—8 bytes on a 64-bit machine—to
-store a single entry, whereas strings use 1 byte per character. [byte
-arrays]{.idx}[strings/vs. Char.t arrays]{.idx}
+The strings we've encountered thus far are essentially byte arrays,
+and are most often used for textual data.  You could imagine using a
+`char array` (a `char` represents an 8-bit character) for the same
+purpose, but strings are considerably more space-efficient; an `array`
+uses one 8-byte word on a 64-bit machine—to store a single entry,
+whereas strings use one byte per character.  [strings/vs. Char.t
+arrays]{.idx}
 
-Strings also come with their own syntax for getting and setting values:
+Unlike arrays, though, strings are immutable, and sometimes, it's
+convenient to have a space-efficient, mutable array of bytes. Happily,
+OCaml has that, via the `bytes` type.
 
+You can set individual characters using `Bytes.set`, and a value of
+type `bytes` can be converted to and from the `string` type.
+
+```ocaml env=main
+# let b = Bytes.of_string "foobar";;
+val b : bytes = "foobar"
+# Bytes.set b 0 (Char.uppercase (Bytes.get b 0));;
+- : unit = ()
+# Bytes.to_string b;;
+- : string = "Foobar"
 ```
-<string_expr>.[<index_expr>]
-<string_expr>.[<index_expr>] <- <char_expr>
-```
-
-And string literals are bounded by quotes. There's also a module `String`
-where you'll find useful functions for working with strings.
 
 #### Bigarrays
 

--- a/book/runtime-memory-layout/README.md
+++ b/book/runtime-memory-layout/README.md
@@ -456,12 +456,14 @@ referring to these guidelines and your source code.
 
 ## String Values
 
-Strings are standard OCaml blocks with the header size defining the size of
-the string in machine words. The `String_tag` (252) is higher than the
-`No_scan_tag`, indicating that the contents of the block are opaque to the
-collector. The block contents are the contents of the string, with padding
-bytes to align the block on a word boundary. [strings/memory representation
-of]{.idx}[runtime memory representation/string values]{.idx}
+OCaml `string`s (and their mutable cousins, `bytes`) are standard
+OCaml blocks with the header size defining the size of the string in
+machine words. The `String_tag` (252) is higher than the
+`No_scan_tag`, indicating that the contents of the block are opaque to
+the collector. The block contents are the contents of the string, with
+padding bytes to align the block on a word boundary. [strings/memory
+representation of]{.idx}[runtime memory representation/string
+values]{.idx}
 
 \
 ![](images/memory-repr/string_block.png "String block layout")
@@ -477,13 +479,14 @@ Given a string length modulo 4:
 - `2` has padding `00 01`
 - `3` has padding `00`
 
-This string representation is a clever way to ensure that the contents are
-always zero-terminated by the padding word and to still compute its length
-efficiently without scanning the whole string. The following formula is used:
+This string representation is a clever way to ensure that the contents
+are always zero-terminated by the padding word and to still compute
+its length efficiently without scanning the whole string. The
+following formula is used:
 
-\
-![](images/memory-repr/string_size_calc.png "String size calculation")
-\
+```
+number_of_words_in_block * sizeof(word) - last_byte_of_block - 1
+```
 
 The guaranteed `NULL` termination comes in handy when passing a string to C,
 but is not relied upon to compute the length from OCaml code. OCaml strings


### PR DESCRIPTION
Add coverage of bytes in two chapters: imperative programming and runtime-representation of values. Also, changed a graphic related to strings to just be an inline plain-text representation of the equation.

Closes #3529