### PR TITLE
Update dune version in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ libraries. To set up your RWO development environment you can run:
 
 ```
 opam switch create rwo 4.09.0
-opam install dune=2.0.1
+opam install dune=2.9.1
 ```
 
 ### Generating the HTML


### PR DESCRIPTION
The min supported version was bumped several times so now it you install dune2.0.1 you can't run make.

Also, you need to have dozens other packages to successfully compile the book, for example:
 basictex, pandoc and dozen packages like `tlmgr install framed `.

and there are build failures https://github.com/realworldocaml/book/issues/3547


