### PR TITLE
Fix missing `next_line` reference

### DIFF
--- a/book/parsing-with-ocamllex-and-menhir/examples/parsing/lexer.mll
+++ b/book/parsing-with-ocamllex-and-menhir/examples/parsing/lexer.mll
@@ -1,5 +1,4 @@
 {
-open Lexing
 open Parser
 
 exception SyntaxError of string
@@ -17,7 +16,7 @@ let id = ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '0'-'9' '_']*
 rule read =
   parse
   | white    { read lexbuf }
-  | newline  { next_line lexbuf; read lexbuf }
+  | newline  { Lexing.new_line lexbuf; read lexbuf }
   | int      { INT (int_of_string (Lexing.lexeme lexbuf)) }
   | float    { FLOAT (float_of_string (Lexing.lexeme lexbuf)) }
   | "true"   { TRUE }


### PR DESCRIPTION
Commit 4c244abfa67cea3b465a9df3e7e357c58d73ae11 removed `next_line` so this one also switches to `Lexing.new_line` accordingly.