### PR TITLE
Add remaining semicolons that were left out before

### DIFF
--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -1288,12 +1288,12 @@ From a syntactic perspective, you should note the keywords that distinguish a
 Here's an example run of this code:
 
 ```ocaml env=main,non-deterministic
-# let ar = Array.init 20 ~f:(fun i -> i)
+# let ar = Array.init 20 ~f:(fun i -> i);;
 val ar : int array =
   [|0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15; 16; 17; 18; 19|]
-# permute ar
+# permute ar;;
 - : unit = ()
-# ar
+# ar;;
 - : int array =
 [|12; 16; 5; 13; 1; 6; 0; 7; 15; 19; 14; 4; 2; 11; 3; 8; 17; 9; 10; 18|]
 ```

--- a/book/imperative-programming/README.md
+++ b/book/imperative-programming/README.md
@@ -944,10 +944,10 @@ val time : (unit -> 'a) -> 'a = <fun>
 And now we can use this to try out some examples:
 
 ```ocaml env=main,non-deterministic=command
-# time (fun () -> edit_distance "OCaml" "ocaml")
+# time (fun () -> edit_distance "OCaml" "ocaml");;
 Time: 0.655651092529 ms
 - : int = 2
-# time (fun () -> edit_distance "OCaml 4.09" "ocaml 4.09")
+# time (fun () -> edit_distance "OCaml 4.09" "ocaml 4.09");;
 Time: 2541.6533947 ms
 - : int = 2
 ```
@@ -981,10 +981,10 @@ This is, however, exponentially slow, for the same reason that
 `fib`. It shows up quite dramatically in the performance:
 
 ```ocaml env=main,non-deterministic=command
-# time (fun () -> fib 20)
+# time (fun () -> fib 20);;
 Time: 1.14369392395 ms
 - : int = 6765
-# time (fun () -> fib 40)
+# time (fun () -> fib 40);;
 Time: 14752.7184486 ms
 - : int = 102334155
 ```
@@ -999,12 +999,12 @@ memoize it after the fact and expect the first call to `fib` to be
 improved.
 
 ```ocaml env=main,non-deterministic=command
-# let fib = memoize (module Int) fib
+# let fib = memoize (module Int) fib;;
 val fib : int -> int = <fun>
-# time (fun () -> fib 40)
+# time (fun () -> fib 40);;
 Time: 18174.5970249 ms
 - : int = 102334155
-# time (fun () -> fib 40)
+# time (fun () -> fib 40);;
 Time: 0.00524520874023 ms
 - : int = 102334155
 ```
@@ -1075,9 +1075,9 @@ using a `let rec`, which for reasons we'll describe later wouldn't work here.
 Using `memo_rec`, we can now build an efficient version of `fib`:
 
 ```ocaml env=main,non-deterministic=command
-# let fib = memo_rec (module Int) fib_norec
+# let fib = memo_rec (module Int) fib_norec;;
 val fib : int -> int = <fun>
-# time (fun () -> fib 40)
+# time (fun () -> fib 40);;
 Time: 0.121355056763 ms
 - : int = 102334155
 ```
@@ -1165,7 +1165,7 @@ one we started with; the following call is many thousands of times
 faster than it was without memoization.
 
 ```ocaml env=main,non-deterministic=command
-# time (fun () -> edit_distance ("OCaml 4.09","ocaml 4.09"))
+# time (fun () -> edit_distance ("OCaml 4.09","ocaml 4.09"));;
 Time: 0.964403152466 ms
 - : int = 2
 ```
@@ -1230,10 +1230,10 @@ without explicit mutation:
 ```ocaml env=main,non-deterministic=command
 # let lazy_memo_rec m f_norec x =
     let rec f = lazy (memoize m (fun x -> f_norec (force f) x)) in
-    (force f) x
+    (force f) x;;
 val lazy_memo_rec : 'a Hashtbl.Key.t -> (('a -> 'b) -> 'a -> 'b) -> 'a -> 'b =
   <fun>
-# time (fun () -> lazy_memo_rec (module Int) fib_norec 40)
+# time (fun () -> lazy_memo_rec (module Int) fib_norec 40);;
 Time: 0.181913375854 ms
 - : int = 102334155
 ```
@@ -1531,7 +1531,7 @@ middle of its work, it won't actually close the file. If we try to read a
 file that doesn't actually contain numbers, we'll see such an error:
 
 ```ocaml env=main,non-deterministic=command
-# sum_file "/etc/hosts"
+# sum_file "/etc/hosts";;
 Exception:
 (Failure
   "Int.of_string: \"127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4\"")
@@ -1541,9 +1541,9 @@ And if we do this over and over in a loop, we'll eventually run out of file
 descriptors:
 
 ```ocaml skip
-# for i = 1 to 10000 do try ignore (sum_file "/etc/hosts") with _ -> () done
+# for i = 1 to 10000 do try ignore (sum_file "/etc/hosts") with _ -> () done;;
 - : unit = ()
-# sum_file "numbers.txt"
+# sum_file "numbers.txt";;
 Error: I/O error: ...: Too many open files
 ```
 

--- a/book/lists-and-patterns/README.md
+++ b/book/lists-and-patterns/README.md
@@ -229,13 +229,13 @@ the `core_bench` library, which can be installed by running
 `opam install core_bench` from the command line.
 
 ```ocaml env=main,non-deterministic=command
-# #require "core_bench"
-# open Core_bench
+# #require "core_bench";;
+# open Core_bench;;
 # [ Bench.Test.create ~name:"plus_one_match" (fun () ->
         plus_one_match 10)
   ; Bench.Test.create ~name:"plus_one_if" (fun () ->
         plus_one_if 10) ]
-  |> Bench.bench
+  |> Bench.bench;;
 Estimated testing time 20s (2 benchmarks x 10s). Change using -quota SECS.
 ┌────────────────┬──────────┐
 │ Name           │ Time/Run │
@@ -265,7 +265,7 @@ Again, we can benchmark these to see the difference:
 # let numbers = List.range 0 1000 in
   [ Bench.Test.create ~name:"sum_if" (fun () -> sum_if numbers)
   ; Bench.Test.create ~name:"sum"    (fun () -> sum numbers) ]
-  |> Bench.bench
+  |> Bench.bench;;
 Estimated testing time 20s (2 benchmarks x 10s). Change using -quota SECS.
 ┌────────┬──────────┐
 │ Name   │ Time/Run │
@@ -344,7 +344,7 @@ well-formatted text table, as follows:
          ["C"    ;"Dennis Ritchie";"1969"] ;
          ["ML"   ;"Robin Milner"  ;"1973"] ;
          ["OCaml";"Xavier Leroy"  ;"1996"] ;
-  ])
+  ]);;
 | language | architect      | first release |
 |----------+----------------+---------------|
 | Lisp     | John McCarthy  | 1958          |

--- a/book/records/README.md
+++ b/book/records/README.md
@@ -818,13 +818,13 @@ Here's an example of `show_field` in action:
                 session_id = "26685";
                 time = Time_ns.of_string "2017-07-21 10:11:45 EST";
                 user = "yminsky";
-                credentials = "Xy2d9W"; }
+                credentials = "Xy2d9W"; };;
 val logon : Logon.t =
   {Logon.session_id = "26685"; time = 2017-07-21 15:11:45.000000000Z;
    user = "yminsky"; credentials = "Xy2d9W"}
-# show_field Logon.Fields.user Fn.id logon
+# show_field Logon.Fields.user Fn.id logon;;
 - : string = "user: yminsky"
-# show_field Logon.Fields.time Time_ns.to_string logon
+# show_field Logon.Fields.time Time_ns.to_string logon;;
 - : string = "time: 2017-07-21 15:11:45.000000000Z"
 ```
 
@@ -872,9 +872,9 @@ the fields of a `Logon` record:
       ~session_id:(print Fn.id)
       ~time:(print Time_ns.to_string)
       ~user:(print Fn.id)
-      ~credentials:(print Fn.id)
+      ~credentials:(print Fn.id);;
 val print_logon : Logon.t -> unit = <fun>
-# print_logon logon
+# print_logon logon;;
 session_id: 26685
 time: 2017-07-21 15:11:45.000000000Z
 user: yminsky


### PR DESCRIPTION
For some reason when running the tests I missed out the remaining error messages, so to be sure this time I cleaned the build and built it from scratch.

Really embarassing, that.