### PR TITLE
Add a disclaimer for #require - ing the base module.

### DIFF
--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -61,7 +61,14 @@ Our first step is to open `Base`:
 
 By opening `Base`, we make the definitions it contains available without
 having to reference `Base` explicitly. This is required for many of the
-examples in the tour and in the remainder of the book.
+examples in the tour and in the remainder of the book. 
+
+Note that for this to work, your `~/.ocamlinit` file should contain the following line: 
+```ocaml env=main 
+#require "base";;
+```
+If it is not included, you may get an `Unbound module Base` error, so be sure that it is in there.
+
 
 Now let's try a few simple numerical calculations:
 


### PR DESCRIPTION
Some people - like me - might experience that the `~/.ocamlinit` file was not generated automatically, so opening `Base` in utop may throw the `Unbound module Base` error. I fixed this by appending this line to my `~/.ocamlinit`:
```ocaml env=main
#require "base";;
```
I think it would be nice to include a disclaimere that all modules that should be opened have to have the `#require` directive. I'm a beginner though, maybe I made a mistake...