### PR TITLE
Review of files-modules-and-programs

### DIFF
--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -671,26 +671,28 @@ Error: Unbound value foo
 - : int = 3
 ```
 
-`open` is essential when you want to modify your environment for a standard
-library like `Base`, but it's generally good style to keep the opening of
-modules to a minimum. Opening a module is basically a trade-off between
-terseness and explicitness—the more modules you open, the fewer module
-qualifications you need, and the harder it is to look at an identifier and
-figure out where it comes from.
-
-Here's some general advice on how to deal with `open`s:
+Here's some general advice on how to use `open` effectively.
 
 ### Open modules rarely
 
-Opening modules at the toplevel of a module should be done quite
-sparingly, and generally only with modules that have been specifically
-designed to be opened, like `Base` or `Option.Monad_infix`.
+`open` is essential when you're using an alternative standard library
+like `Base`, but it's generally good style to keep the opening of
+modules to a minimum. Opening a module is basically a trade-off
+between terseness and explicitness—the more modules you open, the
+fewer module qualifications you need, and the harder it is to look at
+an identifier and figure out where it comes from.
+
+When you do use `open`, it should mostly be with modules that were
+designed to be opened, like `Base` itself, or `Option.Monad_infix` or
+`Float.O` within `Base`..
 
 ### Prefer local opens
 
-If you do need to do an `open`, it's better to do a *local open*. There
-are two syntaxes for local opens. For example, you can write: [local
-opens]{.idx}
+It's generally better to keep down the amount of code affected by an
+`open`. One great tool for this is *local open*s, which let you
+restrict the scope of an open to an arbitrary expression. There are
+two syntaxes for local opens. The following example shows the `let
+open` syntax; [local opens]{.idx}
 
 ```ocaml env=main
 # let average x y =
@@ -702,8 +704,8 @@ val average : int64 -> int64 -> int64 = <fun>
 Here, `of_int` and the infix operators are the ones from the `Int64`
 module.
 
-There's another, even more lightweight syntax for local `open`s, which
-is particularly useful for small expressions:
+The following shows off a more lightweight syntax which is
+particularly useful for small expressions.
 
 ```ocaml env=main
 # let average x y =

--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -51,8 +51,7 @@ open Base
 open Stdio
 
 let build_counts () =
-  In_channel.fold_lines In_channel.stdin ~init:[]
-    ~f:(fun counts line ->
+  In_channel.fold_lines In_channel.stdin ~init:[] ~f:(fun counts line ->
       let count =
         match List.Assoc.find ~equal:String.equal counts line with
         | None -> 0
@@ -367,8 +366,9 @@ val touch : t -> string -> t
 val to_list : t -> (string * int) list
 ```
 
-Note that we needed to add `empty` and `to_list` to `Counter`, since
-otherwise there would be no way to create a `Counter.t` or get data out of
+\noindent
+We added `empty` and `to_list` to `Counter`, since without
+them there would be no way to create a `Counter.t` or get data out of
 one.
 
 We also used this opportunity to document the module. The `mli` file is the
@@ -376,7 +376,7 @@ place where you specify your module's interface, and as such is a natural
 place to put documentation. We started our comments with a double asterisk to
 cause them to be picked up by the `odoc` tool when generating API
 documentation. We'll discuss `odoc` more in
-[The Compiler Frontend Parsing And Type Checking](compiler-frontend.html#the-compiler-frontend-parsing-and-type-checking){data-type=xref}.
+[The OCaml Platform](platform.html#browsing-interface-documentation){data-type=xref}.
 
 Here's a rewrite of `counter.ml` to match the new `counter.mli`:
 
@@ -435,6 +435,7 @@ let () =
   |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)
 ```
 
+\noindent
 With this implementation, the build now succeeds!
 
 ```sh dir=examples/correct/freq-with-sig-abstract-fixed
@@ -448,7 +449,7 @@ an alternate and far more efficient implementation, based on `Base`'s
 ```ocaml file=examples/correct/freq-fast/counter.ml
 open Base
 
-type t = (string, int, String.comparator_witness) Map.t
+type t = int Map.M(String).t
 
 let empty = Map.empty (module String)
 let to_list t = Map.to_alist t
@@ -463,9 +464,10 @@ let touch t s =
 ```
 
 There's some unfamiliar syntax in the above example, in particular the
-use of `Map.empty (module String)` to generate an empty map. Here,
-we're making use of a more advanced feature of the language
-(specifically, *first-class modules*, which we'll get to in later
+use of `int Map.M(String).t` to indicate the type of a map, and
+`Map.empty (module String)` to generate an empty map. Here, we're
+making use of a more advanced feature of the language (specifically,
+functors and first-class modules, which we'll get to in later
 chapters). The use of these features for the Map data-structure in
 particular is covered in [Maps And Hash
 Tables](maps-and-hashtables.html#maps-and-hash-tables){data-type=xref}.
@@ -516,9 +518,9 @@ there's no name clash here. Adding the following two lines to `counter.mli`
 does the trick.
 
 ```ocaml file=examples/correct/freq-median/counter.mli,part=1
-(** Represents the median computed from a set of strings.  In the case where
-    there is an even number of choices, the one before and after the median is
-    returned.  *)
+(** Represents the median computed from a set of strings. In the case
+    where there is an even number of choices, the one before and after
+    the median is returned. *)
 type median =
   | Median of string
   | Before_and_after of string * string
@@ -925,9 +927,9 @@ different order: [type definition mismatches]{.idx}[errors/module type
 definition mismatches]{.idx}[modules/type definition mismatches]{.idx}
 
 ```ocaml file=examples/erroneous/freq-with-type-mismatch/counter.mli,part=1
-(** Represents the median computed from a set of strings.  In the case where
-    there is an even number of choices, the one before and after the median is
-    returned.  *)
+(** Represents the median computed from a set of strings. In the case
+    where there is an even number of choices, the one before and after
+    the median is returned. *)
 type median =
   | Before_and_after of string * string
   | Median of string

--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -688,7 +688,7 @@ designed to be opened, like `Base` or `Option.Monad_infix`.
 
 ### Prefer local opens
 
-If you do need to do an open, it's better to do a *local open*. There
+If you do need to do an `open`, it's better to do a *local open*. There
 are two syntaxes for local opens. For example, you can write: [local
 opens]{.idx}
 

--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -134,15 +134,14 @@ executable. [-linkpkg]{.idx}
 While this works well enough for a one-file project, more complicated
 projects require a tool to orchestrate the build. One good tool for
 this task is `dune`. To invoke `dune`, you need to have two files: a
-`dune-project` file for the overall project,q and a `dune` file that
+`dune-project` file for the overall project, and a `dune` file that
 configures the particular directory.  This is a single-directory
 project, so we'll just have one of each, but more realistic projects
 will have one `dune-project` and many `dune` files. [dune]{.idx}
 [dune-project]{.idx}
 
-The `dune-project` file can contain a lot of project-level metadata,
-but at it's simplest, it can just specify the version of the `dune`
-configuration-language in use.
+At its simplest, the `dune-project` just specifies the version of the
+`dune` configuration-language in use.
 
 ```scheme file=examples/correct/freq-dune/dune-project
 (lang dune 3.0)
@@ -165,11 +164,11 @@ With that in place, we can invoke `dune` as follows.
 $ dune build freq.exe
 ```
 
-We can run the resulting executable, `freq.exe`, from the command line.
-Executables built with `dune` will be left in the `_build/default`
-directory, from which they can be invoked.  The specific invocation
-below will count the words that come up in the file `freq.ml`
-itself. [OCaml toolchain/dune]{.idx}
+We can run the resulting executable, `freq.exe`, from the command
+line.  Executables built with `dune` will be left in the
+`_build/default` directory, from which they can be invoked.  The
+specific invocation below will count the words that come up in the
+file `freq.ml` itself. [OCaml toolchain/dune]{.idx}
 
 ```sh dir=examples/correct/freq-dune
 $ grep -Eo '[[:alpha:]]+' freq.ml | ./_build/default/freq.exe
@@ -201,6 +200,10 @@ $ grep -Eo '[[:alpha:]]+' freq.ml | dune exec ./freq.exe
   2: f
   2: l
 ```
+
+We've really just scratched the surface of what can be done with
+`dune`.  We'll discuss `dune` in more detail in [The OCaml
+Platform](platform.html){data-type=xref}.
 
 
 ::: {data-type=note}

--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -27,7 +27,7 @@ here: [List.Assoc module/List.Assoc.add]{.idx}[List.Assoc
 module/List.Assoc.find]{.idx}[lists/adding new bindings
 in]{.idx}[lists/finding key associations in]{.idx}
 
-```ocaml env=intro
+```ocaml env=main
 # open Base;;
 # let assoc = [("one", 1); ("two",2); ("three",3)];;
 val assoc : (string * int) list = [("one", 1); ("two", 2); ("three", 3)]
@@ -480,12 +480,12 @@ you'll want to make a type in your interface *concrete*, by including the
 type definition in the interface. [concrete types]{.idx}[signatures/concrete
 types]{.idx}
 
-For example, imagine we wanted to add a function to `Counter` for returning
-the line with the median frequency count. If the number of lines is even,
-then there is no precise median, and the function would return the lines
-before and after the median instead. We'll use a custom type to represent the
-fact that there are two possible return values. Here's a possible
-implementation:
+For example, imagine we wanted to add a function to `Counter` for
+returning the line with the median frequency count. If the number of
+lines is even, then there is no single median, and the function would
+return the lines before and after the median instead. We'll use a
+custom type to represent the fact that there are two possible return
+values. Here's a possible implementation:
 
 ```ocaml file=examples/correct/freq-median/counter.ml,part=1
 type median =
@@ -658,7 +658,6 @@ environment that the compiler looks at to find the definition of various
 identifiers. Here's an example:
 
 ```ocaml env=main
-# open Base;;
 # module M = struct let foo = 3 end;;
 module M : sig val foo : int end
 # foo;;
@@ -676,14 +675,19 @@ terseness and explicitness—the more modules you open, the fewer module
 qualifications you need, and the harder it is to look at an identifier and
 figure out where it comes from.
 
-Here's some general advice on how to deal with `open`s: [local opens]{.idx}
+Here's some general advice on how to deal with `open`s:
 
-- Opening modules at the toplevel of a module should be done quite sparingly,
-  and generally only with modules that have been specifically designed to be
-  opened, like `Base` or `Option.Monad_infix`.
+### Open modules rarely
 
-- If you do need to do an open, it's better to do a *local open*. There are
-  two syntaxes for local opens. For example, you can write:
+Opening modules at the toplevel of a module should be done quite
+sparingly, and generally only with modules that have been specifically
+designed to be opened, like `Base` or `Option.Monad_infix`.
+
+### Prefer local opens
+
+If you do need to do an open, it's better to do a *local open*. There
+are two syntaxes for local opens. For example, you can write: [local
+opens]{.idx}
 
 ```ocaml env=main
 # let average x y =
@@ -693,10 +697,10 @@ val average : int64 -> int64 -> int64 = <fun>
 ```
 
 Here, `of_int` and the infix operators are the ones from the `Int64`
-  module.
+module.
 
-  There's another, even more lightweight syntax for local `open`s, which is
-  particularly useful for small expressions:
+There's another, even more lightweight syntax for local `open`s, which
+is particularly useful for small expressions:
 
 ```ocaml env=main
 # let average x y =
@@ -704,9 +708,11 @@ Here, `of_int` and the infix operators are the ones from the `Int64`
 val average : int64 -> int64 -> int64 = <fun>
 ```
 
-- An alternative to local `open`s that makes your code terser without giving
-  up on explicitness is to locally rebind the name of a module. So, when
-  using the `Counter.median` type, instead of writing:
+### Using module shortcuts instead
+
+An alternative to local `open`s that makes your code terser without
+giving up on explicitness is to locally rebind the name of a
+module. So, when using the `Counter.median` type, instead of writing:
 
 ```ocaml file=examples/correct/freq-median/use_median_1.ml,part=1
 let print_median m =
@@ -727,9 +733,9 @@ let print_median m =
     printf "Before and after median:\n   %s\n   %s\n" before after
 ```
 
-Because the module name `C` only exists for a short scope, it's easy to
-  read and remember what `C` stands for. Rebinding modules to very short
-  names at the top level of your module is usually a mistake.
+Because the module name `C` only exists for a short scope, it's easy
+to read and remember what `C` stands for. Rebinding modules to very
+short names at the top level of your module is usually a mistake.
 
 ## Including Modules
 
@@ -843,6 +849,7 @@ create a file of common definitions, which in this case we'll call
 module Option = Ext_option
 ```
 
+\noindent
 Then, by opening `Import`, we can shadow `Base`'s `Option` module with
 our extension.
 
@@ -1002,6 +1009,7 @@ between files. We could create such a situation by adding a reference to
 let _build_counts = Freq.build_counts
 ```
 
+\noindent
 In this case, `dune` will notice the error and complain explicitly about
 the cycle:
 
@@ -1065,9 +1073,9 @@ API will be doing so by reading and modifying code that uses the API, not by
 reading the interface definition. By making your API as obvious as possible
 from that perspective, you simplify the lives of your users.
 
-There are many ways of improving readability at the call site. One example is
-labeled arguments (discussed in
-[Labeled Arguments](variables-and-functions.html#labeled-arguments){data-type=xref}),
+There are many ways of improving readability of client code. One
+example is labeled arguments (discussed in [Labeled
+Arguments](variables-and-functions.html#labeled-arguments){data-type=xref}),
 which act as documentation that is available at the call site.
 
 You can also improve readability simply by choosing good names for
@@ -1077,7 +1085,7 @@ for doubling a number: `(fun x -> x * 2)`, a short variable name like
 `x` is best. A good rule of thumb is that names that have a small
 scope should be short, whereas names that have a large scope, like the
 name of a function in a module interface, should be longer and more
-explicit.
+descriptive.
 
 There is of course a tradeoff here, in that making your APIs more
 explicit tends to make them more verbose as well. Another useful rule
@@ -1092,9 +1100,9 @@ in isolation. The interfaces that appear in your codebase should play
 together harmoniously. Part of achieving that is standardizing aspects of
 those interfaces.
 
-`Base`, `Core` and other libraries from the same family have been designed
-with a uniform set of standards in mind around the design of module
-interfaces. Here are some of the guidelines that they use.
+`Base`, `Core` and related libraries have been designed with a uniform
+set of standards in mind around the design of module interfaces. Here
+are some of the guidelines that they use.
 
 - *A module for (almost) every type.* You should mint a module for almost
   every type in your program, and the primary type of a given module should

--- a/book/files-modules-and-programs/examples/correct/abstract-username/.ocamlformat
+++ b/book/files-modules-and-programs/examples/correct/abstract-username/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/correct/abstract-username/abstract_username.ml
+++ b/book/files-modules-and-programs/examples/correct/abstract-username/abstract_username.ml
@@ -2,12 +2,14 @@ open Base
 
 module Username : sig
   type t
+
   val of_string : string -> t
   val to_string : t -> string
-  val (=) : t -> t -> bool
+  val ( = ) : t -> t -> bool
 end = struct
   type t = string
+
   let of_string x = x
   let to_string x = x
-  let (=) = String.(=)
+  let ( = ) = String.( = )
 end

--- a/book/files-modules-and-programs/examples/correct/ext-option/.ocamlformat
+++ b/book/files-modules-and-programs/examples/correct/ext-option/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/correct/ext-option/ext_option.mli
+++ b/book/files-modules-and-programs/examples/correct/ext-option/ext_option.mli
@@ -1,7 +1,7 @@
 open Base
 
 (* Include the interface of the option module from Base *)
-include (module type of Option)
+include module type of Option
 
 (* Signature of function we're adding *)
 val apply : ('a -> 'b) t -> 'a -> 'b t

--- a/book/files-modules-and-programs/examples/correct/ext-option/use_import.ml
+++ b/book/files-modules-and-programs/examples/correct/ext-option/use_import.ml
@@ -1,5 +1,4 @@
 open Base
 open Import
 
-let lookup_and_apply map key x =
-  Option.apply (Map.find map key) x
+let lookup_and_apply map key x = Option.apply (Map.find map key) x

--- a/book/files-modules-and-programs/examples/correct/freq-dune/.ocamlformat
+++ b/book/files-modules-and-programs/examples/correct/freq-dune/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/correct/freq-dune/dune-project
+++ b/book/files-modules-and-programs/examples/correct/freq-dune/dune-project
@@ -1,2 +1,1 @@
-(lang dune 2.9)
-(name rwo-example)
+(lang dune 3.0)

--- a/book/files-modules-and-programs/examples/correct/freq-dune/freq.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-dune/freq.ml
@@ -2,17 +2,19 @@ open Base
 open Stdio
 
 let build_counts () =
-  In_channel.fold_lines In_channel.stdin ~init:[] ~f:(fun counts line ->
-    let count =
-      match List.Assoc.find ~equal:String.equal counts line with
-      | None -> 0
-      | Some x -> x
-    in
-    List.Assoc.add ~equal:String.equal counts line (count + 1)
-  )
+  In_channel.fold_lines
+    In_channel.stdin
+    ~init:[]
+    ~f:(fun counts line ->
+      let count =
+        match List.Assoc.find ~equal:String.equal counts line with
+        | None -> 0
+        | Some x -> x
+      in
+      List.Assoc.add ~equal:String.equal counts line (count + 1))
 
 let () =
   build_counts ()
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun l -> List.take l 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/correct/freq-fast/.ocamlformat
+++ b/book/files-modules-and-programs/examples/correct/freq-fast/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/correct/freq-fast/counter.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-fast/counter.ml
@@ -1,6 +1,6 @@
 open Base
 
-type t = (string, int, String.comparator_witness) Map.t
+type t = int Map.M(String).t
 
 let empty = Map.empty (module String)
 let to_list t = Map.to_alist t

--- a/book/files-modules-and-programs/examples/correct/freq-fast/counter.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-fast/counter.ml
@@ -1,9 +1,8 @@
 open Base
 
-type t = (string,int,String.comparator_witness) Map.t
+type t = (string, int, String.comparator_witness) Map.t
 
 let empty = Map.empty (module String)
-
 let to_list t = Map.to_alist t
 
 let touch t s =

--- a/book/files-modules-and-programs/examples/correct/freq-fast/counter.mli
+++ b/book/files-modules-and-programs/examples/correct/freq-fast/counter.mli
@@ -3,13 +3,13 @@ open Base
 (** A collection of string frequency counts *)
 type t
 
-(** The empty set of frequency counts  *)
+(** The empty set of frequency counts *)
 val empty : t
 
 (** Bump the frequency count for the given string. *)
 val touch : t -> string -> t
 
-(** Converts the set of frequency counts to an association list.
-    Every string in the list will show up at most once, and the
-    integers will be at least 1. *)
+(** Converts the set of frequency counts to an association list. Every
+    string in the list will show up at most once, and the integers
+    will be at least 1. *)
 val to_list : t -> (string * int) list

--- a/book/files-modules-and-programs/examples/correct/freq-fast/freq.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-fast/freq.ml
@@ -2,11 +2,14 @@ open Base
 open Stdio
 
 let build_counts () =
-  In_channel.fold_lines In_channel.stdin ~init:Counter.empty ~f:Counter.touch
+  In_channel.fold_lines
+    In_channel.stdin
+    ~init:Counter.empty
+    ~f:Counter.touch
 
 let () =
   build_counts ()
   |> Counter.to_list
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun counts -> List.take counts 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/correct/freq-median/.ocamlformat
+++ b/book/files-modules-and-programs/examples/correct/freq-median/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/correct/freq-median/counter.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-median/counter.ml
@@ -1,8 +1,8 @@
 open Base
+
 type t = int Map.M(String).t
 
 let empty = Map.empty (module String)
-
 let to_list t = Map.to_alist t
 
 let touch t s =
@@ -13,19 +13,20 @@ let touch t s =
   in
   Map.set t ~key:s ~data:(count + 1)
 
-[@@@part "1"] ;;
+[@@@part "1"]
 
-type median = | Median of string
-              | Before_and_after of string * string
+type median =
+  | Median of string
+  | Before_and_after of string * string
 
 let median t =
   let sorted_strings =
-    List.sort (Map.to_alist t)
-      ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+    List.sort (Map.to_alist t) ~compare:(fun (_, x) (_, y) ->
+        Int.descending x y)
   in
   let len = List.length sorted_strings in
   if len = 0 then failwith "median: empty frequency count";
   let nth n = fst (List.nth_exn sorted_strings n) in
   if len % 2 = 1
-  then Median (nth (len/2))
-  else Before_and_after (nth (len/2 - 1), nth (len/2))
+  then Median (nth (len / 2))
+  else Before_and_after (nth ((len / 2) - 1), nth (len / 2))

--- a/book/files-modules-and-programs/examples/correct/freq-median/counter.mli
+++ b/book/files-modules-and-programs/examples/correct/freq-median/counter.mli
@@ -3,22 +3,22 @@ open Base
 (** A collection of string frequency counts *)
 type t
 
-(** The empty set of frequency counts  *)
+(** The empty set of frequency counts *)
 val empty : t
 
 (** Bump the frequency count for the given string. *)
 val touch : t -> string -> t
 
-(** Converts the set of frequency counts to an association list.
-    Every string in the list will show up at most once, and the
-    integers will be at least 1. *)
+(** Converts the set of frequency counts to an association list. Every
+    string in the list will show up at most once, and the integers
+    will be at least 1. *)
 val to_list : t -> (string * int) list
 
 [@@@part "1"]
 
-(** Represents the median computed from a set of strings.  In the case where
-    there is an even number of choices, the one before and after the median is
-    returned.  *)
+(** Represents the median computed from a set of strings. In the case
+    where there is an even number of choices, the one before and after
+    the median is returned. *)
 type median =
   | Median of string
   | Before_and_after of string * string

--- a/book/files-modules-and-programs/examples/correct/freq-median/counter.mli
+++ b/book/files-modules-and-programs/examples/correct/freq-median/counter.mli
@@ -14,12 +14,13 @@ val touch : t -> string -> t
     integers will be at least 1. *)
 val to_list : t -> (string * int) list
 
-[@@@part "1"] ;;
+[@@@part "1"]
 
 (** Represents the median computed from a set of strings.  In the case where
     there is an even number of choices, the one before and after the median is
     returned.  *)
-type median = | Median of string
-              | Before_and_after of string * string
+type median =
+  | Median of string
+  | Before_and_after of string * string
 
 val median : t -> median

--- a/book/files-modules-and-programs/examples/correct/freq-median/freq.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-median/freq.ml
@@ -2,11 +2,14 @@ open Base
 open Stdio
 
 let build_counts () =
-  In_channel.fold_lines In_channel.stdin ~init:Counter.empty ~f:Counter.touch
+  In_channel.fold_lines
+    In_channel.stdin
+    ~init:Counter.empty
+    ~f:Counter.touch
 
 let () =
   build_counts ()
   |> Counter.to_list
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun counts -> List.take counts 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/correct/freq-median/use_median_1.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-median/use_median_1.ml
@@ -2,6 +2,7 @@ open! Base
 open Stdio
 
 [@@@part "1"]
+
 let print_median m =
   match m with
   | Counter.Median string -> printf "True median:\n   %s\n" string

--- a/book/files-modules-and-programs/examples/correct/freq-median/use_median_2.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-median/use_median_2.ml
@@ -2,6 +2,7 @@ open! Base
 open Stdio
 
 [@@@part "1"]
+
 let print_median m =
   let module C = Counter in
   match m with

--- a/book/files-modules-and-programs/examples/correct/freq-with-counter/.ocamlformat
+++ b/book/files-modules-and-programs/examples/correct/freq-with-counter/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/correct/freq-with-counter/freq.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-with-counter/freq.ml
@@ -6,6 +6,6 @@ let build_counts () =
 
 let () =
   build_counts ()
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun l -> List.take l 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/correct/freq-with-sig-abstract-fixed/.ocamlformat
+++ b/book/files-modules-and-programs/examples/correct/freq-with-sig-abstract-fixed/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/correct/freq-with-sig-abstract-fixed/counter.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-with-sig-abstract-fixed/counter.ml
@@ -3,11 +3,10 @@ open Base
 type t = (string * int) list
 
 let empty = []
-
 let to_list x = x
 
 let touch counts line =
-  let count = 
+  let count =
     match List.Assoc.find ~equal:String.equal counts line with
     | None -> 0
     | Some x -> x

--- a/book/files-modules-and-programs/examples/correct/freq-with-sig-abstract-fixed/counter.mli
+++ b/book/files-modules-and-programs/examples/correct/freq-with-sig-abstract-fixed/counter.mli
@@ -3,12 +3,12 @@ open Base
 (** A collection of string frequency counts *)
 type t
 
-(** The empty set of frequency counts  *)
+(** The empty set of frequency counts *)
 val empty : t
 
 (** Bump the frequency count for the given string. *)
 val touch : t -> string -> t
 
-(** Converts the set of frequency counts to an association list.  A string shows
-    up at most once, and the counts are >= 1. *)
+(** Converts the set of frequency counts to an association list. A
+    string shows up at most once, and the counts are >= 1. *)
 val to_list : t -> (string * int) list

--- a/book/files-modules-and-programs/examples/correct/freq-with-sig-abstract-fixed/freq.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-with-sig-abstract-fixed/freq.ml
@@ -2,11 +2,14 @@ open Base
 open Stdio
 
 let build_counts () =
-  In_channel.fold_lines In_channel.stdin ~init:Counter.empty ~f:Counter.touch
+  In_channel.fold_lines
+    In_channel.stdin
+    ~init:Counter.empty
+    ~f:Counter.touch
 
 let () =
   build_counts ()
   |> Counter.to_list
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun counts -> List.take counts 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/correct/freq-with-sig/.ocamlformat
+++ b/book/files-modules-and-programs/examples/correct/freq-with-sig/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/correct/freq-with-sig/counter.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-with-sig/counter.ml
@@ -1,7 +1,7 @@
 open Base
 
 let touch counts line =
-  let count = 
+  let count =
     match List.Assoc.find ~equal:String.equal counts line with
     | None -> 0
     | Some x -> x

--- a/book/files-modules-and-programs/examples/correct/freq-with-sig/freq.ml
+++ b/book/files-modules-and-programs/examples/correct/freq-with-sig/freq.ml
@@ -6,6 +6,6 @@ let build_counts () =
 
 let () =
   build_counts ()
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun l -> List.take l 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/erroneous/freq-cyclic1/.ocamlformat
+++ b/book/files-modules-and-programs/examples/erroneous/freq-cyclic1/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/erroneous/freq-cyclic1/counter.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq-cyclic1/counter.ml
@@ -3,7 +3,6 @@ open Base
 type t = int Map.M(String).t
 
 let empty = Map.empty (module String)
-
 let to_list t = Map.to_alist t
 
 let touch t s =
@@ -15,4 +14,5 @@ let touch t s =
   Map.set t ~key:s ~data:(count + 1)
 
 [@@@part "1"]
+
 let singleton l = Counter.touch Counter.empty

--- a/book/files-modules-and-programs/examples/erroneous/freq-cyclic1/freq.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq-cyclic1/freq.ml
@@ -2,10 +2,13 @@ open Base
 open Stdio
 
 let build_counts () =
-  In_channel.fold_lines In_channel.stdin ~init:Counter.empty ~f:Counter.touch
+  In_channel.fold_lines
+    In_channel.stdin
+    ~init:Counter.empty
+    ~f:Counter.touch
 
 let () =
   build_counts ()
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun l -> List.take l 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/erroneous/freq-cyclic2/.ocamlformat
+++ b/book/files-modules-and-programs/examples/erroneous/freq-cyclic2/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/erroneous/freq-cyclic2/counter.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq-cyclic2/counter.ml
@@ -3,7 +3,6 @@ open Base
 type t = int Map.M(String).t
 
 let empty = Map.empty (module String)
-
 let to_list t = Map.to_alist t
 
 let touch t s =
@@ -15,4 +14,5 @@ let touch t s =
   Map.set t ~key:s ~data:(count + 1)
 
 [@@@part "1"]
+
 let _build_counts = Freq.build_counts

--- a/book/files-modules-and-programs/examples/erroneous/freq-cyclic2/freq.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq-cyclic2/freq.ml
@@ -2,10 +2,13 @@ open Base
 open Stdio
 
 let build_counts () =
-  In_channel.fold_lines In_channel.stdin ~init:Counter.empty ~f:Counter.touch
+  In_channel.fold_lines
+    In_channel.stdin
+    ~init:Counter.empty
+    ~f:Counter.touch
 
 let () =
   build_counts ()
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun l -> List.take l 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-missing-def/.ocamlformat
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-missing-def/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-missing-def/counter.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-missing-def/counter.ml
@@ -3,11 +3,10 @@ open Base
 type t = (string * int) list
 
 let empty = []
-
 let to_list x = x
 
 let touch counts line =
-  let count = 
+  let count =
     match List.Assoc.find ~equal:String.equal counts line with
     | None -> 0
     | Some x -> x

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-missing-def/counter.mli
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-missing-def/counter.mli
@@ -3,7 +3,7 @@ open Base
 (** A collection of string frequency counts *)
 type t
 
-(** The empty set of frequency counts  *)
+(** The empty set of frequency counts *)
 val empty : t
 
 (** Bump the frequency count for the given string. *)
@@ -16,6 +16,6 @@ val count : t -> string -> int
 
 [@@@part "2"]
 
-(** Converts the set of frequency counts to an association list.  A string shows
-    up at most once, and the counts are >= 1. *)
+(** Converts the set of frequency counts to an association list. A
+    string shows up at most once, and the counts are >= 1. *)
 val to_list : t -> (string * int) list

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-missing-def/freq.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-missing-def/freq.ml
@@ -2,11 +2,14 @@ open Base
 open Stdio
 
 let build_counts () =
-  In_channel.fold_lines In_channel.stdin ~init:Counter.empty ~f:Counter.touch
+  In_channel.fold_lines
+    In_channel.stdin
+    ~init:Counter.empty
+    ~f:Counter.touch
 
 let () =
   build_counts ()
   |> Counter.to_list
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun counts -> List.take counts 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-sig-abstract/.ocamlformat
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-sig-abstract/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-sig-abstract/counter.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-sig-abstract/counter.ml
@@ -3,7 +3,6 @@ open Base
 type t = (string * int) list
 
 let empty = []
-
 let to_list x = x
 
 let touch counts line =

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-sig-abstract/counter.mli
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-sig-abstract/counter.mli
@@ -3,12 +3,12 @@ open Base
 (** A collection of string frequency counts *)
 type t
 
-(** The empty set of frequency counts  *)
+(** The empty set of frequency counts *)
 val empty : t
 
 (** Bump the frequency count for the given string. *)
 val touch : t -> string -> t
 
-(** Converts the set of frequency counts to an association list.  A string shows
-    up at most once, and the counts are >= 1. *)
+(** Converts the set of frequency counts to an association list. A
+    string shows up at most once, and the counts are >= 1. *)
 val to_list : t -> (string * int) list

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-sig-abstract/freq.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-sig-abstract/freq.ml
@@ -6,6 +6,6 @@ let build_counts () =
 
 let () =
   build_counts ()
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun l -> List.take l 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-sig-mismatch/.ocamlformat
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-sig-mismatch/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-sig-mismatch/counter.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-sig-mismatch/counter.ml
@@ -1,9 +1,8 @@
 open Base
 
-type t = (string,int,String.comparator_witness) Map.t
+type t = (string, int, String.comparator_witness) Map.t
 
 let empty = Map.empty (module String)
-
 let to_list t = Map.to_alist t
 
 let touch t s =

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-sig-mismatch/counter.mli
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-sig-mismatch/counter.mli
@@ -10,9 +10,9 @@ val empty : t
     up at most once, and the counts are >= 1. *)
 val to_list : t -> (string * int) list
 
-[@@@part "1"] ;;
+[@@@part "1"]
 
 (** Bump the frequency count for the given string. *)
 val touch : string -> t -> t
 
-[@@@part "2"] ;;
+[@@@part "2"]

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-sig-mismatch/counter.mli
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-sig-mismatch/counter.mli
@@ -3,11 +3,11 @@ open Base
 (** A collection of string frequency counts *)
 type t
 
-(** The empty set of frequency counts  *)
+(** The empty set of frequency counts *)
 val empty : t
 
-(** Converts the set of frequency counts to an association list.  A string shows
-    up at most once, and the counts are >= 1. *)
+(** Converts the set of frequency counts to an association list. A
+    string shows up at most once, and the counts are >= 1. *)
 val to_list : t -> (string * int) list
 
 [@@@part "1"]

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-sig-mismatch/freq.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-sig-mismatch/freq.ml
@@ -2,12 +2,14 @@ open Base
 open Stdio
 
 let build_counts () =
-  In_channel.fold_lines In_channel.stdin ~init:Counter.empty
+  In_channel.fold_lines
+    In_channel.stdin
+    ~init:Counter.empty
     ~f:(fun counter s -> Counter.touch s counter)
 
 let () =
   build_counts ()
   |> Counter.to_list
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun counts -> List.take counts 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-type-mismatch/.ocamlformat
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-type-mismatch/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-type-mismatch/counter.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-type-mismatch/counter.ml
@@ -3,7 +3,6 @@ open Base
 type t = int Map.M(String).t
 
 let empty = Map.empty (module String)
-
 let to_list t = Map.to_alist t
 
 let touch t s =
@@ -15,16 +14,18 @@ let touch t s =
   Map.set t ~key:s ~data:(count + 1)
 
 (* part 1 *)
-type median = | Median of string
-              | Before_and_after of string * string
+type median =
+  | Median of string
+  | Before_and_after of string * string
 
 let median t =
-  let sorted_strings = List.sort (Map.to_alist t)
-                         ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  let sorted_strings =
+    List.sort (Map.to_alist t) ~compare:(fun (_, x) (_, y) ->
+        Int.descending x y)
   in
   let len = List.length sorted_strings in
   if len = 0 then failwith "median: empty frequency count";
   let nth n = fst (List.nth_exn sorted_strings n) in
   if len % 2 = 1
-  then Median (nth (len/2))
-  else Before_and_after (nth (len/2 - 1), nth (len/2))
+  then Median (nth (len / 2))
+  else Before_and_after (nth ((len / 2) - 1), nth (len / 2))

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-type-mismatch/counter.mli
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-type-mismatch/counter.mli
@@ -3,21 +3,21 @@ open Base
 (** A collection of string frequency counts *)
 type t
 
-(** The empty set of frequency counts  *)
+(** The empty set of frequency counts *)
 val empty : t
 
 (** Bump the frequency count for the given string. *)
 val touch : t -> string -> t
 
-(** Converts the set of frequency counts to an association list.  A string shows
-    up at most once, and the counts are >= 1. *)
+(** Converts the set of frequency counts to an association list. A
+    string shows up at most once, and the counts are >= 1. *)
 val to_list : t -> (string * int) list
 
 [@@@part "1"]
 
-(** Represents the median computed from a set of strings.  In the case where
-    there is an even number of choices, the one before and after the median is
-    returned.  *)
+(** Represents the median computed from a set of strings. In the case
+    where there is an even number of choices, the one before and after
+    the median is returned. *)
 type median =
   | Before_and_after of string * string
   | Median of string

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-type-mismatch/counter.mli
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-type-mismatch/counter.mli
@@ -13,12 +13,13 @@ val touch : t -> string -> t
     up at most once, and the counts are >= 1. *)
 val to_list : t -> (string * int) list
 
-[@@@part "1"] ;;
+[@@@part "1"]
 
 (** Represents the median computed from a set of strings.  In the case where
     there is an even number of choices, the one before and after the median is
     returned.  *)
-type median = | Before_and_after of string * string
-              | Median of string
+type median =
+  | Before_and_after of string * string
+  | Median of string
 
 val median : t -> median

--- a/book/files-modules-and-programs/examples/erroneous/freq-with-type-mismatch/freq.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq-with-type-mismatch/freq.ml
@@ -2,11 +2,14 @@ open Base
 open Stdio
 
 let build_counts () =
-  In_channel.fold_lines In_channel.stdin ~init:Counter.empty ~f:Counter.touch
+  In_channel.fold_lines
+    In_channel.stdin
+    ~init:Counter.empty
+    ~f:Counter.touch
 
 let () =
   build_counts ()
   |> Counter.to_list
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun counts -> List.take counts 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/erroneous/freq/freq.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq/freq.ml
@@ -2,8 +2,7 @@ open Base
 open Stdio
 
 let build_counts () =
-  In_channel.fold_lines In_channel.stdin ~init:[]
-    ~f:(fun counts line ->
+  In_channel.fold_lines In_channel.stdin ~init:[] ~f:(fun counts line ->
       let count =
         match List.Assoc.find ~equal:String.equal counts line with
         | None -> 0

--- a/book/files-modules-and-programs/examples/erroneous/freq/freq.ml
+++ b/book/files-modules-and-programs/examples/erroneous/freq/freq.ml
@@ -2,17 +2,17 @@ open Base
 open Stdio
 
 let build_counts () =
-  In_channel.fold_lines In_channel.stdin ~init:[] ~f:(fun counts line ->
-    let count =
-      match List.Assoc.find ~equal:String.equal counts line with
-      | None -> 0
-      | Some x -> x
-    in
-    List.Assoc.add ~equal:String.equal counts line (count + 1)
-  )
+  In_channel.fold_lines In_channel.stdin ~init:[]
+    ~f:(fun counts line ->
+      let count =
+        match List.Assoc.find ~equal:String.equal counts line with
+        | None -> 0
+        | Some x -> x
+      in
+      List.Assoc.add ~equal:String.equal counts line (count + 1))
 
 let () =
   build_counts ()
-  |> List.sort ~compare:(fun (_,x) (_,y) -> Int.descending x y)
+  |> List.sort ~compare:(fun (_, x) (_, y) -> Int.descending x y)
   |> (fun l -> List.take l 10)
-  |> List.iter ~f:(fun (line,count) -> printf "%3d: %s\n" count line)
+  |> List.iter ~f:(fun (line, count) -> printf "%3d: %s\n" count line)

--- a/book/files-modules-and-programs/examples/erroneous/session_info/.ocamlformat
+++ b/book/files-modules-and-programs/examples/erroneous/session_info/.ocamlformat
@@ -1,0 +1,1 @@
+../../ocamlformat

--- a/book/files-modules-and-programs/examples/erroneous/session_info/session_info.ml
+++ b/book/files-modules-and-programs/examples/erroneous/session_info/session_info.ml
@@ -3,25 +3,27 @@ module Time = Core.Time
 
 module type ID = sig
   type t
+
   val of_string : string -> t
   val to_string : t -> string
-  val (=) : t -> t -> bool
+  val ( = ) : t -> t -> bool
 end
 
 module String_id = struct
   type t = string
+
   let of_string x = x
   let to_string x = x
-  let (=) = String.(=)
+  let ( = ) = String.( = )
 end
 
 module Username : ID = String_id
 module Hostname : ID = String_id
 
-type session_info = { user: Username.t;
-                      host: Hostname.t;
-                      when_started: Time.t;
-                    }
+type session_info =
+  { user : Username.t
+  ; host : Hostname.t
+  ; when_started : Time.t
+  }
 
-let sessions_have_same_user s1 s2 =
-  Username.(=) s1.user s2.host
+let sessions_have_same_user s1 s2 = Username.( = ) s1.user s2.host

--- a/book/files-modules-and-programs/examples/ocamlformat
+++ b/book/files-modules-and-programs/examples/ocamlformat
@@ -1,0 +1,5 @@
+version=0.20.1
+profile=janestreet
+let-binding-spacing=compact
+margin=70
+wrap-comments=true


### PR DESCRIPTION
Result of final reread of files-modules-and-programs.

- Some small whitespace and formatting fixes
- Very small language changes
- Explained dune-project file, which is now required by dune.
- Added some cross-references to the platform chapter
- Fixed a bunch of overlong code blocks with ocamlformat. Added a shared ocamlformat for all examples in the chapter, and symlinked .ocamlformat files of individual examples up to that. Maybe that should be done in other chapters...