### PR TITLE
changed all notes to 4 #'s

### DIFF
--- a/book/command-line-parsing/README.md
+++ b/book/command-line-parsing/README.md
@@ -1002,7 +1002,7 @@ the shell fragment into your global
 loaded in all of your login shells. [completion handlers]{.idx}
 
 ::: {data-type=note}
-##### Installing a Generic Completion Handler
+#### Installing a Generic Completion Handler
 
 Sadly, `bash` doesn't support installing a generic handler for all
 Command-based applications. This means you have to install the completion

--- a/book/compiler-backend/README.md
+++ b/book/compiler-backend/README.md
@@ -153,7 +153,7 @@ variable in as few comparisons as possible. [pattern matching/fundamental
 algorithms in]{.idx}
 
 ::: {data-type=note}
-##### Learning More About Pattern Matching Compilation
+#### Learning More About Pattern Matching Compilation
 
 Pattern matching is an important part of OCaml programming. You'll often
 encounter deeply nested pattern matches over complex data structures in real
@@ -316,19 +316,19 @@ examples:
 
 ```sh dir=examples/back-end
 $ ocamlc -dinstr pattern_monomorphic_small.ml 2>&1
-	branch L2
-L1:	acc 0
-	branchifnot L3
-	const 101
-	return 1
-L3:	const 100
-	return 1
-L2:	closure L1, 0
-	push
-	acc 0
-	makeblock 1, 0
-	pop 1
-	setglobal Pattern_monomorphic_small!
+    branch L2
+L1: acc 0
+    branchifnot L3
+    const 101
+    return 1
+L3: const 100
+    return 1
+L2: closure L1, 0
+    push
+    acc 0
+    makeblock 1, 0
+    pop 1
+    setglobal Pattern_monomorphic_small!
 
 ```
 
@@ -342,7 +342,7 @@ arity). You can find full details
 compiler/instruction set for]{.idx}
 
 ::: {data-type=note}
-##### Where Did the Bytecode Instruction Set Come From?
+#### Where Did the Bytecode Instruction Set Come From?
 
 The bytecode interpreter is much slower than compiled native code, but is
 still remarkably performant for an interpreter without a JIT compiler. Its
@@ -741,7 +741,7 @@ iterations in a tight inner loop, it's worth manually peering at the produced
 assembly code to see if you can hand-optimize it.
 
 ::: {data-type=note}
-##### Accessing Stdlib modules from within Core
+#### Accessing Stdlib modules from within Core
 
 In the benchmark above comparing polymorphic and monomorphic comparison,
 you may have noticed that we prepended the comparison functions with `Stdlib`.
@@ -1017,7 +1017,7 @@ runs and compare them against each other. You can read more on the
 [home page](http://perf.wiki.kernel.org). [frame pointers]{.idx}
 
 ::: {data-type=note}
-##### Using the Frame Pointer to Get More Accurate Traces
+#### Using the Frame Pointer to Get More Accurate Traces
 
 Although Perf doesn't require adding in explicit probes to the binary, it
 does need to understand how to unwind function calls so that the kernel can
@@ -1080,7 +1080,7 @@ later) that resolve symbols from left to right in a single
 pass.[debugging/activating debug runtime]{.idx}
 
 ::: {data-type=note}
-##### Activating the Debug Runtime
+#### Activating the Debug Runtime
 
 Despite your best efforts, it is easy to introduce a bug into some
 components, such as C bindings, that causes heap invariants to be violated.

--- a/book/compiler-backend/README.md
+++ b/book/compiler-backend/README.md
@@ -316,19 +316,19 @@ examples:
 
 ```sh dir=examples/back-end
 $ ocamlc -dinstr pattern_monomorphic_small.ml 2>&1
-    branch L2
-L1: acc 0
-    branchifnot L3
-    const 101
-    return 1
-L3: const 100
-    return 1
-L2: closure L1, 0
-    push
-    acc 0
-    makeblock 1, 0
-    pop 1
-    setglobal Pattern_monomorphic_small!
+	branch L2
+L1:	acc 0
+	branchifnot L3
+	const 101
+	return 1
+L3:	const 100
+	return 1
+L2:	closure L1, 0
+	push
+	acc 0
+	makeblock 1, 0
+	pop 1
+	setglobal Pattern_monomorphic_small!
 
 ```
 

--- a/book/compiler-frontend/README.md
+++ b/book/compiler-frontend/README.md
@@ -65,7 +65,7 @@ high-performance applications.[compilation process/compiler source
 code]{.idx}[code compilers/bytecode vs. native code]{.idx}
 
 ::: {data-type=note}
-##### Obtaining the Compiler Source Code
+#### Obtaining the Compiler Source Code
 
 Although it's not necessary to understand the examples, you may find it
 useful to have a copy of the OCaml source tree checked out while you read
@@ -615,7 +615,7 @@ Error: The implementation conflicting_interface.ml
 ```
 
 ::: {.allow_break data-type=note}
-##### Which Comes First: The ml or the mli?
+#### Which Comes First: The ml or the mli?
 
 There are two schools of thought on which order OCaml code should be written
 in. It's very easy to begin writing code by starting with an `ml` file and
@@ -1015,7 +1015,7 @@ up a cross-compilation environment). [cmi files]{.idx}[files/cmi
 files]{.idx}[OCaml toolchain/ocamlogjinfo]{.idx}
 
 ::: {data-type=note}
-##### Inspecting Compilation Units with ocamlobjinfo
+#### Inspecting Compilation Units with ocamlobjinfo
 
 For separate compilation to be sound, we need to ensure that all the
 `cmi` files used to type-check a module are the same across compilation runs.
@@ -1033,9 +1033,9 @@ $ ocamlobjinfo typedef.cmi
 File typedef.cmi
 Unit name: Typedef
 Interfaces imported:
-	cdd43318ee9dd1b187513a4341737717	Typedef
-	9b04ecdc97e5102c1d342892ef7ad9a2	Pervasives
-	79ae8c0eb753af6b441fe05456c7970b	CamlinternalFormatBasics
+    cdd43318ee9dd1b187513a4341737717    Typedef
+    9b04ecdc97e5102c1d342892ef7ad9a2    Pervasives
+    79ae8c0eb753af6b441fe05456c7970b    CamlinternalFormatBasics
 ```
 
 `ocamlobjinfo` examines the compiled interface and displays what other

--- a/book/concurrent-programming/README.md
+++ b/book/concurrent-programming/README.md
@@ -388,7 +388,7 @@ you should stick to the simpler map/bind/return style of working with
 deferreds when you can.
 
 ::: {data-type=note}
-##### Understanding `bind` in terms of ivars and `upon`
+#### Understanding `bind` in terms of ivars and `upon`
 
 Here's roughly what happens when you write `let d' = Deferred.bind d ~f`.
 
@@ -478,7 +478,7 @@ unbounded amounts of memory, as it keeps track of all the data it
 intends to write but hasn't been able to yet.
 
 ::: {data-type=note}
-##### Tail-calls and chains of deferreds
+#### Tail-calls and chains of deferreds
 
 There's another memory problem you might be concerned about, which is
 the allocation of deferreds.  If you think about the execution of
@@ -576,7 +576,7 @@ $ killall echo.exe
 ```
 
 ::: {data-type=note}
-##### Functions that Never Return
+#### Functions that Never Return
 
 The call to `never_returns` around the call to `Scheduler.go` is a
 little bit surprising, but it has a purpose: to make it clear to
@@ -1604,7 +1604,7 @@ function interface is discussed in more detail in
 [Foreign Function Interface](foreign-function-interface.html#foreign-function-interface){data-type=xref}.
 
 ::: {data-type=note}
-##### Multicore OCaml
+#### Multicore OCaml
 
 OCaml doesn't support truly parallel threads today, but it will soon.
 The current development branch of OCaml, which is expected to be

--- a/book/data-serialization/README.md
+++ b/book/data-serialization/README.md
@@ -81,7 +81,7 @@ converting s-expressions to and from strings: [pretty printers]{.idx}
 ```
 
 ::: {data-type=note}
-##### Base, Core, and Parsexp
+#### Base, Core, and Parsexp
 
 In these examples, we're using Core rather than Base because Core has
 integrated support for parsing s-expressions, courtesy of the
@@ -164,7 +164,7 @@ Exception:
 ```
 
 ::: {data-type=note}
-##### More on Top-Level Printing
+#### More on Top-Level Printing
 
 The values of the s-expressions that we created were printed properly
 as s-expressions in the toplevel, instead of as the tree of `Atom` and
@@ -287,7 +287,7 @@ definitions, implementing functionality that you could in theory have
 implemented by hand, but with far less programmer effort.
 
 ::: {data-type=note}
-##### Syntax Extensions and PPX
+#### Syntax Extensions and PPX
 
 OCaml doesn't directly support deriving s-expression converters from type
 definitions. Instead, it provides a mechanism called *PPX* which allows you

--- a/book/error-handling/README.md
+++ b/book/error-handling/README.md
@@ -292,7 +292,7 @@ large, complex examples with many stages of error handling, the `bind`
 idiom becomes clearer and easier to manage.
 
 ::: {data-type=note}
-##### Monads and `Let_syntax`
+#### Monads and `Let_syntax`
 
 We can make this look a little bit more ordinary by using a syntax
 extension that's designed specifically for monadic binds, called
@@ -466,7 +466,7 @@ type system will let us throw an exception anywhere in a program. [sexp
 declaration]{.idx}[exceptions/textual representation of]{.idx}
 
 ::: {.allow_break data-type=note}
-##### Declaring Exceptions Using `[@@deriving sexp]`
+#### Declaring Exceptions Using `[@@deriving sexp]`
 
 OCaml can't always generate a useful textual representation of an exception.
 For example:

--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -84,7 +84,7 @@ print them to the screen. These operations are tied together using the
 [let ( ) declaration]{.idx}[main function]{.idx}
 
 ::: {.allow_break data-type=note}
-##### Where Is `main`?
+#### Where Is `main`?
 
 Unlike programs in C, Java or C#, programs in OCaml don't have a unique
 `main` function. When an OCaml program is evaluated, all the statements in
@@ -207,7 +207,7 @@ Platform](platform.html){data-type=xref}.
 
 
 ::: {data-type=note}
-##### Bytecode Versus Native Code
+#### Bytecode Versus Native Code
 
 OCaml ships with two compilers: the `ocamlopt` native code compiler
 and the `ocamlc` bytecode compiler.  Programs compiled with `ocamlc`

--- a/book/files-modules-and-programs/README.md
+++ b/book/files-modules-and-programs/README.md
@@ -203,7 +203,7 @@ $ grep -Eo '[[:alpha:]]+' freq.ml | dune exec ./freq.exe
 
 We've really just scratched the surface of what can be done with
 `dune`.  We'll discuss `dune` in more detail in [The OCaml
-Platform](platform.html){data-type=xref}.
+Platform](platform.html#the-ocaml-platform){data-type=xref}.
 
 
 ::: {data-type=note}

--- a/book/first-class-modules/README.md
+++ b/book/first-class-modules/README.md
@@ -258,7 +258,7 @@ connect the types associated with a first-class module to the types of other
 values you're working with.
 
 ::: {data-type=note}
-##### More on Locally Abstract Types
+#### More on Locally Abstract Types
 
 One of the key properties of locally abstract types is that they're dealt
 with as abstract types in the function they're defined within, but are

--- a/book/foreign-function-interface/README.md
+++ b/book/foreign-function-interface/README.md
@@ -34,7 +34,7 @@ looks. We'll create a binding to the Ncurses terminal toolkit, as it's widely
 available on most systems and doesn't have any complex dependencies.
 
 ::: {data-type=note}
-## Installing the Ctypes Library
+#### Installing the Ctypes Library
 
 If you want to use Ctypes interactively, you'll also need to install the
 [`libffi`](https://github.com/atgreen/libffi) library as a prerequisite to
@@ -783,7 +783,7 @@ Mon Oct 11 15:57:38 2021
 ```
 
 ::: {data-type=note}
-##### Why Do We Need to Use returning?
+#### Why Do We Need to Use returning?
 
 The alert reader may be curious about why all these function definitions have
 to be terminated by `returning`:
@@ -1067,7 +1067,7 @@ Ctypes]{.idx}[Ctypes library/lifetime of allocated
 Ctypes]{.idx}[garbage collection/of allocated Ctypes]{.idx}
 
 ::: {data-type=note}
-##### Lifetime of Allocated Ctypes
+#### Lifetime of Allocated Ctypes
 
 Values allocated via Ctypes (i.e., using `allocate`, `Array.make`, and so on)
 will not be garbage-collected as long as they are reachable from OCaml

--- a/book/gadts/README.md
+++ b/book/gadts/README.md
@@ -1540,7 +1540,7 @@ be called in each of the duplicated cases.
 <!-- TODO: Fix forward references -->
 
 As will be discussed in more detail in [Data Serialization With
-S-Expressions](data-serialization.html){data-type=xref},
+S-Expressions](data-serialization.html#data-serialization-with-s-expressions){data-type=xref},
 s-expressions are a convenient data format for representing structured
 data.  Rather than write the serializers and deserializers by hand, we
 typically use `ppx_sexp_value`, which is a syntax extension which

--- a/book/garbage-collector/README.md
+++ b/book/garbage-collector/README.md
@@ -68,7 +68,7 @@ major and minor heaps to account for this generational difference. We'll
 explain how they differ in more detail next.
 
 ::: {data-type=note}
-##### The Gc Module and OCAMLRUNPARAM
+#### The Gc Module and OCAMLRUNPARAM
 
 OCaml provides several mechanisms to query and alter the behavior of
 the runtime system. The `Gc` module provides this functionality from
@@ -155,7 +155,7 @@ of points necessary to ensure these checks happen in a bounded amount of time.
 [minor heaps/setting size of]{.idx}
 
 ::: {data-type=note}
-##### Setting the Size of the Minor Heap
+#### Setting the Size of the Minor Heap
 
 The default minor heap size in OCaml is normally 2 MB on 64-bit platforms,
 but this is increased to 8 MB if you use Core (which generally prefers
@@ -572,13 +572,13 @@ Benchmark for mutable, immutable
   barrier_bench.exe [COLUMN ...]
 
 Columns that can be specified are:
-	time       - Number of nano secs taken.
-	cycles     - Number of CPU cycles (RDTSC) taken.
-	alloc      - Allocation of major, minor and promoted words.
-	gc         - Show major and minor collections per 1000 runs.
-	percentage - Relative execution time as a percentage.
-	speedup    - Relative execution cost as a speedup.
-	samples    - Number of samples collected for profiling.
+    time       - Number of nano secs taken.
+    cycles     - Number of CPU cycles (RDTSC) taken.
+    alloc      - Allocation of major, minor and promoted words.
+    gc         - Show major and minor collections per 1000 runs.
+    percentage - Relative execution time as a percentage.
+    speedup    - Relative execution cost as a speedup.
+    samples    - Number of samples collected for profiling.
 
 ```
 
@@ -607,7 +607,7 @@ for]{.idx}[finalizers/in grabage collection]{.idx}[garbage
 collection/finalizer functions]{.idx}
 
 ::: {data-type=note}
-##### What Values Can Be Finalized?
+#### What Values Can Be Finalized?
 
 Various values cannot have finalizers attached since they aren't
 heap-allocated. Some examples of values that are not heap-allocated are

--- a/book/garbage-collector/README.md
+++ b/book/garbage-collector/README.md
@@ -572,13 +572,13 @@ Benchmark for mutable, immutable
   barrier_bench.exe [COLUMN ...]
 
 Columns that can be specified are:
-    time       - Number of nano secs taken.
-    cycles     - Number of CPU cycles (RDTSC) taken.
-    alloc      - Allocation of major, minor and promoted words.
-    gc         - Show major and minor collections per 1000 runs.
-    percentage - Relative execution time as a percentage.
-    speedup    - Relative execution cost as a speedup.
-    samples    - Number of samples collected for profiling.
+	time       - Number of nano secs taken.
+	cycles     - Number of CPU cycles (RDTSC) taken.
+	alloc      - Allocation of major, minor and promoted words.
+	gc         - Show major and minor collections per 1000 runs.
+	percentage - Relative execution time as a percentage.
+	speedup    - Relative execution cost as a speedup.
+	samples    - Number of samples collected for profiling.
 
 ```
 

--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -1026,7 +1026,7 @@ comparison operators when you want them. OCaml also offers a special set of
 *polymorphic comparison operators* that can work on almost any type, but
 those are considered to be problematic, and so are hidden by default by
 `Base`. We'll learn more about polymorphic compare in
-[Terser and Faster Patterns](lists-and-patterns.html#terser-and-faster-patterns){data-type=xref}
+[Terser and Faster Patterns](lists-and-patterns.html#terser-and-faster-patterns){data-type=xref}.
 :::
 
 

--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -1219,7 +1219,7 @@ This isn't the most idiomatic way to sum up a list, but it shows how you can
 use a `ref` in place of a mutable variable.
 
 ::: {data-type=note}
-#### Nesting lets with let and in
+#### Nesting lets with `let` and `in`
 
 The definition of `sum` in the above examples was our first use of
 `let` to define a new variable within the body of a function. A `let`

--- a/book/guided-tour/README.md
+++ b/book/guided-tour/README.md
@@ -19,7 +19,7 @@ Before going any further, make sure you've followed the steps in [the
 installation page](http://dev.realworldocaml.org/install.html).
 
 ::: {data-type=note}
-##### `Base` and `Core`
+#### `Base` and `Core`
 
 `Base` comes along with another, yet more extensive standard library
 replacement, called `Core`.  We're going to mostly stick to `Base`,
@@ -390,7 +390,7 @@ whereas `"short"` and `"loooooong"` require that `'a` be instantiated as
 `string`, and they can't both be right at the same time.
 
 ::: {data-type=note}
-##### Type Errors Versus Exceptions
+#### Type Errors Versus Exceptions
 
 There's a big difference in OCaml between errors that are caught at compile
 time and those that are caught at runtime. It's better to catch errors as early
@@ -501,7 +501,7 @@ This is just a first taste of pattern matching. Pattern matching is a
 pervasive tool in OCaml, and as you'll see, it has surprising power.
 
 ::: {data-type=note}
-##### Operators in `Base` and the stdlib
+#### Operators in `Base` and the stdlib
 
 OCaml's standard library and `Base` mostly use the same operators for
 the same things, but there are some differences.  For example, in
@@ -599,7 +599,7 @@ started with, as you can see below:
 ```
 
 ::: {data-type=note}
-##### Semicolons Versus Commas
+#### Semicolons Versus Commas
 
 Unlike many other languages, OCaml uses semicolons to separate list elements
 in lists rather than commas. Commas, instead, are used for separating
@@ -1015,7 +1015,7 @@ case, we're using `List.exists` to check if there is a scene element within
 which our point resides.
 
 ::: {data-type=note}
-##### `Base` and polymorphic comparison
+#### `Base` and polymorphic comparison
 
 One other thing to notice was the fact that we opened `Float.O` in the
 definition of `is_inside_scene_element`. That allowed us to use the simple,
@@ -1219,7 +1219,7 @@ This isn't the most idiomatic way to sum up a list, but it shows how you can
 use a `ref` in place of a mutable variable.
 
 ::: {data-type=note}
-##### Nesting lets with let and in
+#### Nesting lets with let and in
 
 The definition of `sum` in the above examples was our first use of
 `let` to define a new variable within the body of a function. A `let`

--- a/book/imperative-programming/README.md
+++ b/book/imperative-programming/README.md
@@ -602,7 +602,7 @@ let prev elt = elt.prev
 These all follow relatively straightforwardly from our type definitions.
 
 ::: {data-type=note}
-##### Cyclic Data Structures
+#### Cyclic Data Structures
 
 Doubly linked lists are a cyclic data structure, meaning that it is possible
 to follow a nontrivial sequence of pointers that closes in on itself. In
@@ -1187,7 +1187,7 @@ Time: 0.964403152466 ms
 ```
 
 ::: {.allow_break data-type=note}
-##### Limitations of let rec
+#### Limitations of let rec
 
 You might wonder why we didn't tie the recursive knot in `memo_rec` using
 `let rec`, as we did for `make_rec` earlier. Here's code that tries to do
@@ -1408,7 +1408,7 @@ Error: This expression has type float but an expression was expected of type
 ```
 
 ::: {data-type=note}
-##### Understanding Format Strings
+#### Understanding Format Strings
 
 The format strings used by `printf` turn out to be quite different
 from ordinary strings. This difference ties to the fact that OCaml's

--- a/book/json/README.md
+++ b/book/json/README.md
@@ -75,7 +75,7 @@ of]{.idx}[static checking]{.idx}[compile-time static
 checking]{.idx}[unit tests]{.idx}
 
 ::: {data-type=note}
-##### Installing the Yojson Library
+#### Installing the Yojson Library
 
 There are several JSON libraries available for OCaml. For this
 chapter, we've picked the popular
@@ -263,7 +263,7 @@ strongly typed OCaml value. [combinators/functional
 combinators]{.idx}[functional combinators]{.idx}
 
 ::: {data-type=note}
-##### Functional Combinators
+#### Functional Combinators
 
 Combinators are a design pattern that crops up quite often in functional
 programming. John Hughes defines them as "a function which builds program
@@ -465,7 +465,7 @@ compile time. [errors/type errors]{.idx}[type checking]{.idx}[polymorphic
 variant types/type checking and]{.idx}[type inference/benefits of]{.idx}
 
 ::: {data-type=note}
-##### Polymorphic Variants and Easier Type Checking
+#### Polymorphic Variants and Easier Type Checking
 
 One difficulty you will encounter is that type errors involving polymorphic
 variants can be quite verbose. For example, suppose you build an `Assoc` and

--- a/book/lists-and-patterns/README.md
+++ b/book/lists-and-patterns/README.md
@@ -472,7 +472,7 @@ table.[strings/concatenation of]{.idx}[String.concat]{.idx}[List
 module/String.concat and]{.idx}
 
 ::: {data-type=note}
-#### Performance of String.concat and ^
+#### Performance of `String.concat` and `^`
 
 In the preceding code we’ve concatenated strings two different ways:
 `String.concat`, which operates on lists of strings; and `^`, which is

--- a/book/lists-and-patterns/README.md
+++ b/book/lists-and-patterns/README.md
@@ -472,7 +472,7 @@ table.[strings/concatenation of]{.idx}[String.concat]{.idx}[List
 module/String.concat and]{.idx}
 
 ::: {data-type=note}
-##### Performance of String.concat and ^
+#### Performance of String.concat and ^
 
 In the preceding code we’ve concatenated strings two different ways:
 `String.concat`, which operates on lists of strings; and `^`, which is
@@ -882,7 +882,7 @@ val remove_sequential_duplicates : int list -> int list = <fun>
 <!-- other way of integrating this in to the text. -->
 
 ::: {data-type=note}
-##### Polymorphic Compare
+#### Polymorphic Compare
 
 You might have noticed that `remove_sequential_duplicates` is
 specialized to lists of integers.  That's because `Base`'s default

--- a/book/maps-and-hashtables/README.md
+++ b/book/maps-and-hashtables/README.md
@@ -548,7 +548,7 @@ total order suitable for creating maps and sets with, then
 `[@@deriving compare]` is a good choice.
 
 ::: {data-type=note}
-##### =, ==, and phys_equal
+#### =, ==, and phys_equal
 
 OCaml has multiple notions of equality, and picking the right one can
 be tricky.  If you don't open `Base`, you'll find that the `==`

--- a/book/objects/README.md
+++ b/book/objects/README.md
@@ -14,7 +14,7 @@ programming]{.idx}[object-oriented programming
 (OOP)]{.idx}[programming/object-oriented programming (OOP)]{.idx}
 
 ::: {data-type=note}
-##### What Is Object-Oriented Programming?
+#### What Is Object-Oriented Programming?
 
 Object-oriented programming (often shortened to OOP) is a programming
 style that encapsulates computation and data within logical
@@ -205,7 +205,7 @@ Error: This expression has type < name : string; width : int >
 ```
 
 ::: {data-type=note}
-##### Elisions Are Polymorphic
+#### Elisions Are Polymorphic
 
 The `..` in an open object type is an elision, standing for "possibly more
 methods." It may not be apparent from the syntax, but an elided object type
@@ -480,7 +480,7 @@ val items : item list = [<obj>; <obj>]
 ```
 
 ::: {data-type=note}
-##### Polymorphic Variant Subtyping
+#### Polymorphic Variant Subtyping
 
 Subtyping can also be used to coerce a polymorphic variant into a larger
 polymorphic variant type. A polymorphic variant type *A* is a subtype of

--- a/book/parsing-with-ocamllex-and-menhir/README.md
+++ b/book/parsing-with-ocamllex-and-menhir/README.md
@@ -37,7 +37,7 @@ of how to build a parser in OCaml. [ocamlyacc parser generator]{.idx}[Menhir
 parser generator/vs. ocamlyacc]{.idx}
 
 ::: {data-type=note}
-##### Menhir Versus ocamlyacc
+#### Menhir Versus ocamlyacc
 
 Menhir is an alternative parser generator that is generally superior to the
 venerable `ocamlyacc`, which dates back quite a few years. Menhir is mostly
@@ -542,7 +542,7 @@ pattern:
   characters; `"true"` is first, so the return value is `TRUE`.
 
 ::: {data-type=note}
-##### Unused lexing values
+#### Unused lexing values
 
 In our parser, we have not used all the token regexps that we defined
 in the lexer.  For instance, `id` is unused since we do not parse
@@ -608,7 +608,7 @@ generator]{.idx}[Camomile unicode parser]{.idx}[Unicode, parsing solutions
 for]{.idx}
 
 ::: {data-type=note}
-##### Handling Unicode
+#### Handling Unicode
 
 We've glossed over an important detail here: parsing Unicode characters to
 handle the full spectrum of the world's writing systems. OCaml has several

--- a/book/platform/README.md
+++ b/book/platform/README.md
@@ -14,7 +14,7 @@ OCaml Platform tools that we'll describe next will do much of the heavy
 lifting.
 
 ::: {data-type=note}
-##### Using the opam source-based package manager
+#### Using the opam source-based package manager
 
 opam is the official package manager and metadata packaging format that is used
 in the OCaml community.  We've been using it in earlier chapters to install
@@ -441,7 +441,7 @@ switch to use. Just the default one should be sufficient get you
 going with building and browsing your interfaces.
 
 ::: {data-type=note}
-##### What is the Language Server Protocol?
+#### What is the Language Server Protocol?
 
 The Language Server Protocol defines a communications standard between
 an editor or IDE and a language-specific server that provides features
@@ -576,7 +576,7 @@ eponymous [opam package manager](https://opam.ocaml.org) that we've
 been using throughout this book.
 
 ::: {data-type=note}
-##### How do we name OCaml modules, libraries and packages?
+#### How do we name OCaml modules, libraries and packages?
 
 Much of the time, the module, library, and package names are all the
 same.  But there are reasons for these names to be distinct as well:
@@ -828,7 +828,7 @@ the package is merged.  Once it is merged, you can navigate to the
 available in the central repository for other users to install.
 
 ::: {data-type=note}
-##### Creating lock files for your projects
+#### Creating lock files for your projects
 
 Before you publish a project, you might also want to create an
 opam lock file to include with the archive. A lock file records

--- a/book/records/README.md
+++ b/book/records/README.md
@@ -230,7 +230,7 @@ It's a good idea to enable the warning for incomplete record matches
 and to explicitly disable it with an `_` where necessary.
 
 ::: {data-type=note}
-##### Compiler Warnings
+#### Compiler Warnings
 
 The OCaml compiler is packed full of useful warnings that can be
 enabled and disabled separately. These are documented in the compiler

--- a/book/runtime-memory-layout/README.md
+++ b/book/runtime-memory-layout/README.md
@@ -27,7 +27,7 @@ you can know rather precisely where a block of performance-critical OCaml
 code is spending its time. [OCaml toolchain/benefits of]{.idx}
 
 ::: {data-type=note}
-##### Why Do OCaml Types Disappear at Runtime?
+#### Why Do OCaml Types Disappear at Runtime?
 
 The OCaml compiler runs through several phases during the compilation
 process. The first phase is syntax checking, during which source files are
@@ -134,7 +134,7 @@ area, it is treated as an opaque C pointer to some other system resource.
 [word-aligned pointers]{.idx}[pointers/word-aligned]{.idx}
 
 ::: {data-type=note}
-##### Some History About OCaml's Word-Aligned Pointers
+#### Some History About OCaml's Word-Aligned Pointers
 
 The alert reader may be wondering how OCaml can guarantee that all of its
 pointers are word-aligned. In the old days, when RISC chips such as Sparc,

--- a/book/testing/README.md
+++ b/book/testing/README.md
@@ -217,7 +217,7 @@ to do the test that's important but is really awkward to expose.  But
 such cases are very much the exception.
 
 ::: {data-type=note}
-##### Why can't inline tests go in executables?
+#### Why can't inline tests go in executables?
 
 We've only talked about putting tests into libraries. What about
 executables? It turns out you can't do this directly, because Dune
@@ -264,7 +264,7 @@ let%expect_test "trivial" = print_endline "Hello World!"
 ```
 
 ::: {data-type=note}
-##### `open` and `open!`
+#### `open` and `open!`
 
 In this example, we use `open!` instead of `open` because we happen
 not to be using any values from `Base`, and so the compiler will warn
@@ -426,7 +426,7 @@ let%expect_test _ =
 ```
 
 ::: {data-type=note}
-##### Quoted strings
+#### Quoted strings
 
 The example above used a new syntax for string literals, called
 *quoted strings*.  Here's an example.

--- a/book/variables-and-functions/README.md
+++ b/book/variables-and-functions/README.md
@@ -153,7 +153,7 @@ values in OCaml, which we'll discuss in
 but there are no mutable variables.
 
 ::: {data-type=note}
-##### Why Don't Variables Vary?
+#### Why Don't Variables Vary?
 
 One source of confusion for people new to OCaml is the fact that variables
 are immutable. This seems pretty surprising even on linguistic terms. Isn't
@@ -327,7 +327,7 @@ syntactic niceties aside, the two styles of function definition are
 equivalent.
 
 ::: {data-type=note}
-##### let and fun
+#### let and fun
 
 Functions and `let` bindings have a lot to do with each other. In some sense,
 you can think of the parameter of a function as a variable being bound to the
@@ -733,7 +733,7 @@ choosing the operator you use with care, particularly with respect to
 associativity.
 
 ::: {data-type=note}
-##### The application operator
+#### The application operator
 
 `|>` is known as the *reverse application operator*. You might be
 unsurprised to learn that there's also an *application

--- a/book/variables-and-functions/README.md
+++ b/book/variables-and-functions/README.md
@@ -327,7 +327,7 @@ syntactic niceties aside, the two styles of function definition are
 equivalent.
 
 ::: {data-type=note}
-#### let and fun
+#### `let` and `fun`
 
 Functions and `let` bindings have a lot to do with each other. In some sense,
 you can think of the parameter of a function as a variable being bound to the

--- a/book/variants/README.md
+++ b/book/variants/README.md
@@ -160,7 +160,7 @@ A muted gray...
 ```
 
 ::: {data-type=note}
-##### Variants, tuples and parens
+#### Variants, tuples and parens
 
 Variants with multiple arguments look an awful lot like tuples.
 Consider the following example of a value of the type `color` we
@@ -933,7 +933,7 @@ Here, the inferred type states that the tags can be no more than ``
 polymorphic variants can lead to fairly complex inferred types.
 
 ::: {.allow_break data-type=note}
-##### Polymorphic Variants and Catch-all Cases
+#### Polymorphic Variants and Catch-all Cases
 
 As we saw with the definition of `is_positive`, a `match` expression
 can lead to the inference of an upper bound on a variant type,


### PR DESCRIPTION
Most were 5, some were not. Should all be the same now.

Also, fixed some titles in notes that should have marked some things as code but didn't. And fixed a handful of cross-references.