### PR TITLE
Chapter 'Classes': simplify code

### DIFF
--- a/book/classes/README.md
+++ b/book/classes/README.md
@@ -956,8 +956,7 @@ class circle r x y = object(self)
   method private contains x' y' =
     let dx = x' - x in
     let dy = y' - y in
-    let dist = sqrt (Float.of_int (dx * dx + dy * dy)) in
-      dist <= (Float.of_int radius)
+      dx * dx + dy * dy <= radius * radius
 
   method on_click ?start ?stop f =
     on_click ?start ?stop
@@ -1028,8 +1027,7 @@ class circle r x y = object
   method private contains x' y' =
     let dx = x' - x in
     let dy = y' - y in
-    let dist = sqrt (Float.of_int (dx * dx + dy * dy)) in
-    dist <= (Float.of_int radius)
+      dx * dx + dy * dy <= radius * radius
 end
 ```
 

--- a/book/classes/README.md
+++ b/book/classes/README.md
@@ -954,9 +954,9 @@ class circle r x y = object(self)
   method draw = fill_circle x y radius
 
   method private contains x' y' =
-    let dx = abs (x' - x) in
-    let dy = abs (y' - y) in
-    let dist = sqrt (Float.of_int ((dx * dx) + (dy * dy))) in
+    let dx = x' - x in
+    let dy = y' - y in
+    let dist = sqrt (Float.of_int (dx * dx + dy * dy)) in
       dist <= (Float.of_int radius)
 
   method on_click ?start ?stop f =
@@ -1026,9 +1026,9 @@ class circle r x y = object
   method draw = fill_circle x y radius
 
   method private contains x' y' =
-    let dx = abs (x' - x) in
-    let dy = abs (y' - y) in
-    let dist = sqrt (Float.of_int ((dx * dx) + (dy * dy))) in
+    let dx = x' - x in
+    let dy = y' - y in
+    let dist = sqrt (Float.of_int (dx * dx + dy * dy)) in
     dist <= (Float.of_int radius)
 end
 ```

--- a/book/classes/README.md
+++ b/book/classes/README.md
@@ -1066,7 +1066,7 @@ has been created.
 
 For example, suppose we wanted to extend our previous shapes module with a
 `growing_circle` class for circles that expand when clicked. We could inherit
-from `circle` and used the inherited `on_click` to add a handler for click
+from `circle` and use the inherited `on_click` to add a handler for click
 events:
 
 ```ocaml file=examples/shapes/shapes.ml,part=3

--- a/book/classes/examples/shapes/shapes.ml
+++ b/book/classes/examples/shapes/shapes.ml
@@ -53,10 +53,9 @@ class circle r x y = object
   method draw = fill_circle x y radius
 
   method private contains x' y' =
-    let dx = abs (x' - x) in
-    let dy = abs (y' - y) in
-    let dist = sqrt (Float.of_int ((dx * dx) + (dy * dy))) in
-    dist <= (Float.of_int radius)
+    let dx = x' - x in
+    let dy = y' - y in
+      dx * dx + dy * dy <= radius * radius
 end
 
 [@@@part "3"] ;;

--- a/book/classes/examples/verbose_shapes.ml
+++ b/book/classes/examples/verbose_shapes.ml
@@ -38,10 +38,9 @@ class circle r x y = object(self)
   method draw = fill_circle x y radius
 
   method private contains x' y' =
-    let dx = abs (x' - x) in
-    let dy = abs (y' - y) in
-    let dist = sqrt (Float.of_int ((dx * dx) + (dy * dy))) in
-      dist <= (Float.of_int radius)
+    let dx = x' - x in
+    let dy = y' - y in
+      dx * dx + dy * dy <= radius * radius
 
   method on_click ?start ?stop f =
     on_click ?start ?stop

--- a/book/maps-and-hashtables/README.md
+++ b/book/maps-and-hashtables/README.md
@@ -475,7 +475,7 @@ As you can see, polymorphic compare now produces a result, but it's
 not the result we want.
 
 The abstraction-breaking nature of polymorphic compare can cause real
-and quite subtle bugs.  If, for example, if you build a map whose keys
+and quite subtle bugs.  If, for example, you build a map whose keys
 are sets (which have the same issues with polymorphic compare that
 maps do), then the map built with the polymorphic comparator will
 behave incorrectly, separating out keys that should be aggregated

--- a/book/maps-and-hashtables/README.md
+++ b/book/maps-and-hashtables/README.md
@@ -117,7 +117,7 @@ We don't need to provide the module again for functions like
 to the comparison function it uses.
 
 Not every module can be used for creating maps, but the standard ones in
-`Base` are. Later in the chapter, we'll show how you can set up a module of your
+`Base` can. Later in the chapter, we'll show how you can set up a module of your
 own so it can be used in this way.
 
 ### Sets


### PR DESCRIPTION
One could also remove the extraneous parentheses around `Float.of_int radius`.

I get an error when running this code. This is because Base/Core removes the polymorphic nature of `<=`. Not sure how to best fix it, if one wants to follow the spirit of that example. Maybe
```
  method private contains x' y' =
    let dx = x' - x in
    let dy = y' - y in
    let dist = Float.sqrt (Float.of_int (dx * dx + dy * dy)) in
      Float.(dist <= of_int radius)
``` 
But why not avoid `Float` altogether ?
```
  method private contains x' y' =
    let dx = x' - x in
    let dy = y' - y in
      dx * dx + dy * dy <= radius * radius
```
@yminsky : tell me if that's ok and I'll gladly implement that latter solution in both instances.