### PR TITLE
GADT Chapter: Permit the naive variant implementation to compare bools

### DIFF
--- a/book/gadts/README.md
+++ b/book/gadts/README.md
@@ -82,7 +82,7 @@ With that in hand, we can write the evaluator itself.
        | Int _ -> raise Ill_typed)
     | Eq (x, y) ->
       (match eval x, eval y with
-       | Bool f1, Bool f2 -> Bool (f1 = f2)
+       | Bool b1, Bool b2 -> Bool (Bool.equal b1 b2)
        | Int f1, Int f2 -> Bool (f1 = f2)
        | Bool _, Int _ | Int _, Bool _ -> raise Ill_typed)
     | Plus (x, y) ->

--- a/book/gadts/README.md
+++ b/book/gadts/README.md
@@ -82,8 +82,9 @@ With that in hand, we can write the evaluator itself.
        | Int _ -> raise Ill_typed)
     | Eq (x, y) ->
       (match eval x, eval y with
-       | Bool _, _ | _, Bool _ -> raise Ill_typed
-       | Int f1, Int f2 -> Bool (f1 = f2))
+       | Bool f1, Bool f2 -> Bool (f1 = f2)
+       | Int f1, Int f2 -> Bool (f1 = f2)
+       | Bool _, Int _ | Int _, Bool _ -> raise Ill_typed)
     | Plus (x, y) ->
       (match eval x, eval y with
        | Bool _, _ | _, Bool _ -> raise Ill_typed


### PR DESCRIPTION
The "desired module type" has this signature for `eq`

```ocaml
val if_ : bool t -> 'a t -> 'a t -> 'a t
```

But the naive implementation throws an exception if it receives anything other than two ints.  This isn't really necessary, so I propose a change to the program which allows it.