### PR TITLE
Fix typo in Maps and Hash Tables

### DIFF
--- a/book/maps-and-hashtables/README.md
+++ b/book/maps-and-hashtables/README.md
@@ -165,7 +165,7 @@ look at the type signature of `Map.of_alist_exn`.
 ```ocaml env=main
 # #show Map.of_alist_exn;;
 val of_alist_exn :
-  ('a, 'cmp) Set.comparator -> ('a * 'b) list -> ('a, 'b, 'cmp) Map.t
+  ('a, 'cmp) Map.comparator -> ('a * 'b) list -> ('a, 'b, 'cmp) Map.t
 ```
 
 The type `Map.comparator` is actually an alias for a first-class module type,


### PR DESCRIPTION
Confirmed signature in utop:
```
utop # Core.Map.of_alist_exn;;
- : ('a, 'cmp) Core.Map.comparator ->
    ('a * 'b) list -> ('a, 'b, 'cmp) Core.Map.t
= <fun>   
```