### PR TITLE
[nit] GADTs: add #require directives for `abstracting` code listings

### DIFF
--- a/book/gadts/README.md
+++ b/book/gadts/README.md
@@ -769,7 +769,12 @@ useful for all sorts of system automation tasks.
 But, can't we write pipelines already? After all, OCaml comes with a
 perfectly serviceable pipeline operator:
 
-<!-- TODO: Maybe add #require's for Sys_unix and Core_unix -->
+<!-- TODO: explain #require -->
+
+```ocaml env=abstracting
+# #require "core_unix";;
+# #require "core_unix.sys_unix";;
+```
 
 ```ocaml env=abstracting
 # open Core;;


### PR DESCRIPTION
In the GADT chapter, the `sum_file_sizes` code makes use of `Sys_unix.ls_dir` and `Core_unix.lstat`.  However, those modules are unbound for readers who are following along in the REPL.  

```ocaml
utop # Sys_unix.ls_dir;;
Error: Unbound module Sys_unix
utop # Core_unix.lstat;;
Error: Unbound module Core_unix
Hint: Did you mean Core__Pid?
utop #
```

This patch simply adds a code listing `#require`ing them, and removes the TODO indicating that there perhaps ought to be such a code listing.

```ocaml
utop # #require "core_unix";;
utop # #require "core_unix.sys_unix";;

utop # Core_unix.lstat;;
- : string -> Core_unix.stats = <fun>
utop # Sys_unix.ls_dir;;
- : string -> string list = <fun>
```

Thank you for an enjoyable book.